### PR TITLE
Document schema registry and module manifest contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.0] - 2025-08-03
+
+### Added
+- Module manifest schema and validation
+  - `src/lib/moduleManifest.ts` defines the manifest contract and AJV validation
+  - `Module` model now includes `version` and `manifest` fields
+- Architecture updated with `Schema Registry` and manifest documentation in README
+
+### Changed
+- Expanded README with module contracts, discovery flow and message broker usage
+
 ## [0.2.0] - 2025-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ flowchart LR
     SubscriptionService("Servicio de Suscripciones")
     ValidationService("Validación AJV")
     AuditService("Servicio de Auditoría")
+    SchemaRegistry("Schema Registry")
     WS("WebSocket / Realtime")
     subgraph Módulos
       InventoryModule("Módulo Inventario")
@@ -63,9 +64,15 @@ flowchart LR
   SubscriptionService <--> CentralDB
   CoreModule <--> ValidationService
   ValidationService <--> CentralDB
-  CoreModule <--> AuditService
-  AuditService <--> CentralDB
-  Browser <-->|WS| LB
+    CoreModule <--> AuditService
+    AuditService <--> CentralDB
+    CoreModule <--> SchemaRegistry
+    SchemaRegistry <--> InventoryModule
+    SchemaRegistry <--> SalesModule
+    SchemaRegistry <--> ProductionModule
+    SchemaRegistry <--> BillingModule
+    SchemaRegistry <--> LogisticsModule
+    Browser <-->|WS| LB
   LB <-->|WS| WS
   WS <--> CoreModule
   CoreModule <--> InventoryModule
@@ -90,6 +97,32 @@ flowchart LR
   Monitoring <--> Broker
   Monitoring <--> Cache
 ```
+
+---
+
+## 🧾 Contrato y Versionado de Módulos
+
+Cada módulo debe proporcionar un **manifest** JSON con metadatos clave (nombre, versión, endpoints, esquemas y eventos). El Módulo Central valida este manifest con AJV y lo almacena en un **Schema Registry** para facilitar la compatibilidad entre versiones.
+
+### Ejemplo de `module.manifest.json`
+
+```json
+{
+  "name": "inventory",
+  "version": "1.0.0",
+  "endpoints": { "rest": "https://inventory.local/api" },
+  "schemas": { "product": { "$id": "#/product", "type": "object" } },
+  "events": { "publish": ["stock.updated"], "subscribe": ["order.created"] }
+}
+```
+
+## 🔍 Descubrimiento y Comunicación
+
+- **Registro inicial**: los módulos se registran vía HTTP enviando su manifest.
+- **Schema Registry**: expone los esquemas y versiones para que otros módulos puedan consultarlos.
+- **Broker de mensajes**: los eventos de negocio se publican/suscriben mediante RabbitMQ/Kafka.
+- **Endpoints HTTP**: se usan para operaciones sincrónicas declaradas en el manifest.
+- **Seguridad**: los tokens y permisos se propagan entre módulos y se auditan todas las llamadas.
 
 ---
 
@@ -181,10 +214,11 @@ El **Módulo Central** gestiona:
 
 ## 🧩 Características Principales
 
-- 📦 **Módulo Central**: orquesta usuarios, suscripciones, módulos y conexiones.  
-- 🔗 **Conexiones Seguras**: define flujos entre módulos usando datos validados por AJV.  
-- 🧱 **Modularidad Extrema**: cada módulo dispone de su esquema, endpoints y UI propios.  
-- 🔒 **Seguridad y Auditaría**: JWT en cada request, cifrado HTTPS/WSS, logs de auditoría (acción, payload, resultado, IP, userAgent).  
+- 📦 **Módulo Central**: orquesta usuarios, suscripciones, módulos y conexiones.
+- 🔗 **Conexiones Seguras**: define flujos entre módulos usando datos validados por AJV.
+- 🧱 **Modularidad Extrema**: cada módulo dispone de su esquema, endpoints y UI propios.
+- 📄 **Manifest de Módulos**: contrato versionado con endpoints, esquemas y eventos.
+- 🔒 **Seguridad y Auditaría**: JWT en cada request, cifrado HTTPS/WSS, logs de auditoría (acción, payload, resultado, IP, userAgent).
 - 📊 **Logs TTL**: los registros de auditoría expiran automáticamente tras 30 días.  
 - 💬 **Componentes UX**: Chat en tiempo real (ChatWidget), scroll infinito (InfiniteScroller), menús de usuario (AuthMenu), formularios de auth (AuthForm).  
 - 📄 **Páginas Estáticas**: landing, privacidad, términos, perfil.
@@ -199,7 +233,7 @@ El **Módulo Central** gestiona:
 │   ├── app/               # Rutas, layouts y API routes
 │   ├── components/        # Componentes React compartidos (AuthForm, AuthMenu, ChatWidget...)
 │   ├── hooks/             # Hooks personalizados (useAuth, useModules...)
-│   ├── lib/               # Utilidades (conexión Mongo, validaciones AJV)
+│   ├── lib/               # Utilidades (conexión Mongo, manifest de módulos)
 │   ├── models/            # Esquemas Mongoose (User, Module, ModuleLink, AuditLog)
 │   └── store/             # Zustand stores
 ├── public/                # Assets estáticos

--- a/src/lib/moduleManifest.ts
+++ b/src/lib/moduleManifest.ts
@@ -1,0 +1,56 @@
+import Ajv, { JSONSchemaType } from 'ajv';
+
+export interface ModuleManifest {
+  name: string;
+  version: string;
+  description?: string;
+  endpoints: {
+    rest: string;
+    ws?: string;
+  };
+  schemas: Record<string, any>;
+  dependencies?: string[];
+  events?: {
+    publish?: string[];
+    subscribe?: string[];
+  };
+}
+
+const manifestSchema: JSONSchemaType<ModuleManifest> = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    endpoints: {
+      type: 'object',
+      properties: {
+        rest: { type: 'string' },
+        ws: { type: 'string', nullable: true },
+      },
+      required: ['rest'],
+      additionalProperties: false,
+    },
+    schemas: { type: 'object', additionalProperties: true },
+    dependencies: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+    events: {
+      type: 'object',
+      properties: {
+        publish: { type: 'array', items: { type: 'string' }, nullable: true },
+        subscribe: { type: 'array', items: { type: 'string' }, nullable: true },
+      },
+      additionalProperties: false,
+      nullable: true,
+    },
+  },
+  required: ['name', 'version', 'endpoints', 'schemas'],
+  additionalProperties: false,
+};
+
+const ajv = new Ajv({ allErrors: true });
+
+export const validateManifest = ajv.compile(manifestSchema);

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -1,14 +1,13 @@
 import mongoose, { Schema, Document, models } from 'mongoose';
-import Ajv, { AnySchema } from 'ajv';
 import mongoosePaginate from 'mongoose-paginate-v2';
-
-const ajv = new Ajv();
+import { ModuleManifest, validateManifest } from '../lib/moduleManifest';
 
 export interface IModule extends Document {
   name: string;
+  version: string;
   description: string;
   ownerId: mongoose.Types.ObjectId;
-  schema: any;
+  manifest: ModuleManifest;
   endpoints: {
     rest: string;
     ws?: string;
@@ -17,9 +16,10 @@ export interface IModule extends Document {
 
 const ModuleSchema: Schema = new Schema({
   name: { type: String, required: true },
+  version: { type: String, required: true },
   description: { type: String, default: '' },
   ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-  schema: { type: Schema.Types.Mixed, required: true },
+  manifest: { type: Schema.Types.Mixed, required: true },
   endpoints: {
     rest: { type: String, required: true },
     ws: { type: String },
@@ -27,10 +27,10 @@ const ModuleSchema: Schema = new Schema({
   deletedAt: Date,
 }, { timestamps: true });
 
-// Validate JSON Schema
+// Validate module manifest
 ModuleSchema.pre('save', function(next) {
-  if (!ajv.validateSchema(this.schema as AnySchema)) {
-    return next(new Error('Invalid module JSON Schema: ' + ajv.errorsText(ajv.errors)));
+  if (!validateManifest(this.manifest as ModuleManifest)) {
+    return next(new Error('Invalid module manifest'));
   }
   next();
 });


### PR DESCRIPTION
## Summary
- add ModuleManifest schema and validation with versioned manifest field
- document Schema Registry and discovery flow in README
- record changes in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d872117c83338388ee8e7b567f04