### PR TITLE
Add module manifest validation tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2025-08-11
+
+### Added
+- Guidance on interpreting and presenting `validateManifest.errors`
+
+## [0.5.1] - 2025-08-10
+
+### Added
+- Tests for module manifest validation and model pre-save hook
+
+## [0.5.0] - 2025-08-03
+
+### Added
+- Module manifest schema and validation
+  - `src/lib/moduleManifest.ts` defines the manifest contract and AJV validation
+  - `Module` model now includes `version` and `manifest` fields
+- Architecture updated with `Schema Registry` and manifest documentation in README
+
+### Changed
+- Expanded README with module contracts, discovery flow and message broker usage
+
 ## [0.2.0] - 2025-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ flowchart LR
     SubscriptionService("Servicio de Suscripciones")
     ValidationService("Validación AJV")
     AuditService("Servicio de Auditoría")
+    SchemaRegistry("Schema Registry")
     WS("WebSocket / Realtime")
     subgraph Módulos
       InventoryModule("Módulo Inventario")
@@ -63,9 +64,15 @@ flowchart LR
   SubscriptionService <--> CentralDB
   CoreModule <--> ValidationService
   ValidationService <--> CentralDB
-  CoreModule <--> AuditService
-  AuditService <--> CentralDB
-  Browser <-->|WS| LB
+    CoreModule <--> AuditService
+    AuditService <--> CentralDB
+    CoreModule <--> SchemaRegistry
+    SchemaRegistry <--> InventoryModule
+    SchemaRegistry <--> SalesModule
+    SchemaRegistry <--> ProductionModule
+    SchemaRegistry <--> BillingModule
+    SchemaRegistry <--> LogisticsModule
+    Browser <-->|WS| LB
   LB <-->|WS| WS
   WS <--> CoreModule
   CoreModule <--> InventoryModule
@@ -90,6 +97,52 @@ flowchart LR
   Monitoring <--> Broker
   Monitoring <--> Cache
 ```
+
+---
+
+## 🧾 Contrato y Versionado de Módulos
+
+Cada módulo debe proporcionar un **manifest** JSON con metadatos clave (nombre, versión, endpoints, esquemas y eventos). El Módulo Central valida este manifest con AJV y lo almacena en un **Schema Registry** para facilitar la compatibilidad entre versiones.
+
+### Ejemplo de `module.manifest.json`
+
+```json
+{
+  "name": "inventory",
+  "version": "1.0.0",
+  "endpoints": { "rest": "https://inventory.local/api" },
+  "schemas": { "product": { "$id": "#/product", "type": "object" } },
+  "events": { "publish": ["stock.updated"], "subscribe": ["order.created"] }
+}
+```
+
+### Validación y manejo de errores
+
+`validateManifest` devuelve `false` si el manifest no cumple el contrato y
+expone los detalles de validación en `validateManifest.errors`. Cada error
+incluye un `instancePath` con la ruta al campo problemático y un `message`
+legible. Se recomienda transformar estos objetos en mensajes claros antes de
+mostrarlos a los autores del módulo:
+
+```ts
+if (!validateManifest(manifest)) {
+  const msgs = (validateManifest.errors ?? []).map(
+    (e) => `${e.instancePath || e.params.missingProperty}: ${e.message}`,
+  );
+  throw new Error(`Manifest inválido:\n${msgs.join('\n')}`);
+}
+```
+
+También puede utilizarse `ajv.errorsText(validateManifest.errors)` para generar
+un resumen legible de todos los problemas detectados.
+
+## 🔍 Descubrimiento y Comunicación
+
+- **Registro inicial**: los módulos se registran vía HTTP enviando su manifest.
+- **Schema Registry**: expone los esquemas y versiones para que otros módulos puedan consultarlos.
+- **Broker de mensajes**: los eventos de negocio se publican/suscriben mediante RabbitMQ/Kafka.
+- **Endpoints HTTP**: se usan para operaciones sincrónicas declaradas en el manifest.
+- **Seguridad**: los tokens y permisos se propagan entre módulos y se auditan todas las llamadas.
 
 ---
 
@@ -181,10 +234,11 @@ El **Módulo Central** gestiona:
 
 ## 🧩 Características Principales
 
-- 📦 **Módulo Central**: orquesta usuarios, suscripciones, módulos y conexiones.  
-- 🔗 **Conexiones Seguras**: define flujos entre módulos usando datos validados por AJV.  
-- 🧱 **Modularidad Extrema**: cada módulo dispone de su esquema, endpoints y UI propios.  
-- 🔒 **Seguridad y Auditaría**: JWT en cada request, cifrado HTTPS/WSS, logs de auditoría (acción, payload, resultado, IP, userAgent).  
+- 📦 **Módulo Central**: orquesta usuarios, suscripciones, módulos y conexiones.
+- 🔗 **Conexiones Seguras**: define flujos entre módulos usando datos validados por AJV.
+- 🧱 **Modularidad Extrema**: cada módulo dispone de su esquema, endpoints y UI propios.
+- 📄 **Manifest de Módulos**: contrato versionado con endpoints, esquemas y eventos.
+- 🔒 **Seguridad y Auditaría**: JWT en cada request, cifrado HTTPS/WSS, logs de auditoría (acción, payload, resultado, IP, userAgent).
 - 📊 **Logs TTL**: los registros de auditoría expiran automáticamente tras 30 días.  
 - 💬 **Componentes UX**: Chat en tiempo real (ChatWidget), scroll infinito (InfiniteScroller), menús de usuario (AuthMenu), formularios de auth (AuthForm).  
 - 📄 **Páginas Estáticas**: landing, privacidad, términos, perfil.
@@ -199,7 +253,7 @@ El **Módulo Central** gestiona:
 │   ├── app/               # Rutas, layouts y API routes
 │   ├── components/        # Componentes React compartidos (AuthForm, AuthMenu, ChatWidget...)
 │   ├── hooks/             # Hooks personalizados (useAuth, useModules...)
-│   ├── lib/               # Utilidades (conexión Mongo, validaciones AJV)
+│   ├── lib/               # Utilidades (conexión Mongo, manifest de módulos)
 │   ├── models/            # Esquemas Mongoose (User, Module, ModuleLink, AuditLog)
 │   └── store/             # Zustand stores
 ├── public/                # Assets estáticos

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",

--- a/src/lib/__tests__/moduleManifest.test.ts
+++ b/src/lib/__tests__/moduleManifest.test.ts
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+import Module from '../../models/Module';
+import { validateManifest, ModuleManifest } from '../moduleManifest';
+
+// Helper to run Mongoose pre-save hooks without DB
+function runPreSave(doc: any) {
+  return new Promise<void>((resolve, reject) => {
+    (doc.constructor as any).schema.s.hooks.execPre('save', doc, (err: Error | null) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+}
+
+describe('validateManifest', () => {
+  it('accepts valid manifest with optional fields', () => {
+    const manifest: ModuleManifest = {
+      name: 'inventory',
+      version: '1.0.0',
+      description: 'Inventory module',
+      endpoints: { rest: '/api/inventory', ws: '/ws/inventory' },
+      schemas: { item: { type: 'object' } },
+      dependencies: ['users'],
+      events: { publish: ['item.updated'], subscribe: ['user.created'] },
+    };
+    assert.equal(validateManifest(manifest), true);
+  });
+
+  it('rejects manifest missing required fields', () => {
+    const manifest: any = {
+      version: '1.0.0',
+      endpoints: { rest: '/api' },
+      schemas: {},
+    };
+    assert.equal(validateManifest(manifest), false);
+  });
+
+  it('rejects manifest with invalid types', () => {
+    const manifest: any = {
+      name: 'test',
+      version: 1,
+      endpoints: { rest: '/api' },
+      schemas: {},
+    };
+    assert.equal(validateManifest(manifest), false);
+  });
+
+  it('rejects manifest with unexpected properties', () => {
+    const manifest: any = {
+      name: 'test',
+      version: '1.0.0',
+      endpoints: { rest: '/api' },
+      schemas: {},
+      extra: true,
+    };
+    assert.equal(validateManifest(manifest), false);
+  });
+
+  it('rejects manifest with malformed nested events', () => {
+    const manifest: any = {
+      name: 'test',
+      version: '1.0.0',
+      endpoints: { rest: '/api' },
+      schemas: {},
+      events: { publish: 'not-array' },
+    };
+    assert.equal(validateManifest(manifest), false);
+  });
+
+  it('rejects manifest with non-object schemas', () => {
+    const manifest: any = {
+      name: 'test',
+      version: '1.0.0',
+      endpoints: { rest: '/api' },
+      schemas: 'invalid',
+    };
+    assert.equal(validateManifest(manifest), false);
+  });
+});
+
+describe('ModuleSchema pre-save', () => {
+  it('allows saving with valid manifest', async () => {
+    const manifest: ModuleManifest = {
+      name: 'inventory',
+      version: '1.0.0',
+      endpoints: { rest: '/api/inventory' },
+      schemas: {},
+    };
+    const mod = new Module({
+      name: 'inventory',
+      version: '1.0.0',
+      description: '',
+      ownerId: new mongoose.Types.ObjectId(),
+      manifest,
+      endpoints: { rest: '/api/inventory' },
+    });
+    await runPreSave(mod); // should not throw
+  });
+
+  it('rejects invalid manifest during save', async () => {
+    const manifest: any = {
+      name: 'inventory',
+      version: '1.0.0',
+      endpoints: { rest: '/api/inventory' },
+      schemas: 'invalid',
+    };
+    const mod = new Module({
+      name: 'inventory',
+      version: '1.0.0',
+      description: '',
+      ownerId: new mongoose.Types.ObjectId(),
+      manifest,
+      endpoints: { rest: '/api/inventory' },
+    });
+    await assert.rejects(runPreSave(mod), /Invalid module manifest/);
+  });
+});
+

--- a/src/lib/moduleManifest.ts
+++ b/src/lib/moduleManifest.ts
@@ -1,0 +1,89 @@
+import Ajv, { JSONSchemaType } from 'ajv';
+
+export interface ModuleManifest {
+  name: string;
+  version: string;
+  description?: string;
+  endpoints: {
+    rest: string;
+    ws?: string;
+  };
+  schemas: Record<string, any>;
+  dependencies?: string[];
+  events?: {
+    publish?: string[];
+    subscribe?: string[];
+  };
+}
+
+// JSON Schema definition describing the shape of a module manifest.
+// The schema is used by AJV to validate manifests at runtime and lists
+// all required fields along with optional ones like `dependencies` or
+// `events`.
+const manifestSchema: JSONSchemaType<ModuleManifest> = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    endpoints: {
+      type: 'object',
+      properties: {
+        rest: { type: 'string' },
+        ws: { type: 'string', nullable: true },
+      },
+      required: ['rest'],
+      additionalProperties: false,
+    },
+    schemas: { type: 'object', additionalProperties: true },
+    dependencies: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+    events: {
+      type: 'object',
+      properties: {
+        publish: { type: 'array', items: { type: 'string' }, nullable: true },
+        subscribe: { type: 'array', items: { type: 'string' }, nullable: true },
+      },
+      additionalProperties: false,
+      nullable: true,
+    },
+  },
+  required: ['name', 'version', 'endpoints', 'schemas'],
+  additionalProperties: false,
+};
+
+// Configure AJV to collect all validation errors instead of stopping after the
+// first one. This produces more actionable feedback for developers.
+const ajv = new Ajv({ allErrors: true });
+
+/**
+ * Validates a candidate manifest object against the JSON schema defined above.
+ *
+ * The returned function follows AJV's {@link import('ajv').AnyValidateFunction}
+ * signature: it returns `true` when the manifest conforms to the schema and
+ * `false` otherwise. When validation fails, callers can inspect
+ * `validateManifest.errors` to obtain a detailed list of
+ * {@link import('ajv').ErrorObject} items describing each problem, such as
+ * missing required fields, invalid types or unexpected properties.
+ *
+ * Each error object includes an `instancePath` (JSON Pointer to the offending
+ * field) and a human‑readable `message`. For a friendlier UX, transform these
+ * objects into concise strings before exposing them to module authors:
+ *
+ * ```ts
+ * if (!validateManifest(manifest)) {
+ *   const messages = (validateManifest.errors ?? []).map(
+ *     (err) => `${err.instancePath || err.params.missingProperty}: ${err.message}`,
+ *   );
+ *   console.error('Invalid manifest:\n' + messages.join('\n'));
+ * }
+ * ```
+ *
+ * `ajv.errorsText(validateManifest.errors)` can also generate a summary
+ * message. Presenting distilled messages instead of raw AJV objects helps keep
+ * validation feedback actionable.
+ */
+export const validateManifest = ajv.compile(manifestSchema);

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -1,14 +1,13 @@
 import mongoose, { Schema, Document, models } from 'mongoose';
-import Ajv, { AnySchema } from 'ajv';
 import mongoosePaginate from 'mongoose-paginate-v2';
-
-const ajv = new Ajv();
+import { ModuleManifest, validateManifest } from '../lib/moduleManifest';
 
 export interface IModule extends Document {
   name: string;
+  version: string;
   description: string;
   ownerId: mongoose.Types.ObjectId;
-  schema: any;
+  manifest: ModuleManifest;
   endpoints: {
     rest: string;
     ws?: string;
@@ -17,9 +16,10 @@ export interface IModule extends Document {
 
 const ModuleSchema: Schema = new Schema({
   name: { type: String, required: true },
+  version: { type: String, required: true },
   description: { type: String, default: '' },
   ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
-  schema: { type: Schema.Types.Mixed, required: true },
+  manifest: { type: Schema.Types.Mixed, required: true },
   endpoints: {
     rest: { type: String, required: true },
     ws: { type: String },
@@ -27,10 +27,10 @@ const ModuleSchema: Schema = new Schema({
   deletedAt: Date,
 }, { timestamps: true });
 
-// Validate JSON Schema
+// Validate module manifest
 ModuleSchema.pre('save', function(next) {
-  if (!ajv.validateSchema(this.schema as AnySchema)) {
-    return next(new Error('Invalid module JSON Schema: ' + ajv.errorsText(ajv.errors)));
+  if (!validateManifest(this.manifest as ModuleManifest)) {
+    return next(new Error('Invalid module manifest'));
   }
   next();
 });


### PR DESCRIPTION
## Summary
- add tests for ModuleManifest validation and Module pre-save hook
- add test script using TypeScript compilation
- record test coverage in changelog
- document how `validateManifest` exposes AJV validation errors
- describe how to interpret and present `validateManifest.errors` for module authors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d872117c83338388ee8e7b567f04