### PR TITLE
feat: verify module version and ping on register

### DIFF
--- a/src/app/api/modules/register/route.ts
+++ b/src/app/api/modules/register/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Module from '@/models/Module';
+import { z } from 'zod';
+
+const registerSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  description: z.string().optional(),
+  ownerId: z.string(),
+  manifest: z.any(),
+  endpoints: z.object({
+    rest: z.string().url(),
+    ws: z.string().url().optional(),
+  }),
+});
+
+const CORE_MODULE_VERSION = process.env.CORE_MODULE_VERSION || '1.0.0';
+
+function isCompatible(version: string): boolean {
+  const coreParts = CORE_MODULE_VERSION.split('.');
+  const moduleParts = version.split('.');
+  return coreParts[0] === moduleParts[0];
+}
+
+export async function POST(req: Request) {
+  await dbConnect();
+
+  try {
+    const body = await req.json();
+    const parse = registerSchema.safeParse(body);
+    if (!parse.success) {
+      return NextResponse.json(
+        { status: 'validation_error', errors: parse.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const data = parse.data;
+    const compatibleVersion = isCompatible(data.version);
+
+    if (!compatibleVersion) {
+      return NextResponse.json(
+        {
+          status: 'incompatible_version',
+          error: `Module version ${data.version} incompatible with core version ${CORE_MODULE_VERSION}`,
+        },
+        { status: 400 }
+      );
+    }
+
+    let status: 'online' | 'offline' = 'offline';
+    let lastHandshake: Date | undefined;
+
+    try {
+      const ping = await fetch(`${data.endpoints.rest.replace(/\/$/, '')}/ping`);
+      if (ping.ok) {
+        status = 'online';
+        lastHandshake = new Date();
+      }
+    } catch (err) {
+      // Module unreachable, keep status offline
+    }
+
+    const module = await Module.create({
+      ...data,
+      status,
+      lastHandshake,
+      compatibleVersion,
+    });
+
+    return NextResponse.json(
+      {
+        status: 'registered',
+        moduleId: module._id,
+        online: status === 'online',
+        message:
+          status === 'online'
+            ? 'Module registered and online.'
+            : 'Module registered but unreachable.',
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error('Module registration error:', error);
+    return NextResponse.json(
+      { status: 'error', error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -12,6 +12,9 @@ export interface IModule extends Document {
     rest: string;
     ws?: string;
   };
+  status: 'online' | 'offline';
+  lastHandshake?: Date;
+  compatibleVersion: boolean;
 }
 
 const ModuleSchema: Schema = new Schema({
@@ -24,6 +27,9 @@ const ModuleSchema: Schema = new Schema({
     rest: { type: String, required: true },
     ws: { type: String },
   },
+  status: { type: String, enum: ['online', 'offline'], default: 'offline' },
+  lastHandshake: Date,
+  compatibleVersion: { type: Boolean, default: false },
   deletedAt: Date,
 }, { timestamps: true });
 


### PR DESCRIPTION
## Summary
- expand Module model to track module status, last handshake and version compatibility
- implement module registration route with version compatibility check and ping validation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998703dd408333ba89ad42aa545e86