### PR TITLE
Add schema registry service and integrate manifest approval

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js && rm -rf .tmp-tests"
+    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts src/services/schemaRegistry/schemaDefinition.model.ts src/services/schemaRegistry/schemaRegistry.controller.ts src/services/schemaRegistry/__tests__/schemaRegistry.controller.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js .tmp-tests/services/schemaRegistry/__tests__/schemaRegistry.controller.test.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",

--- a/src/lib/__tests__/moduleManifest.test.ts
+++ b/src/lib/__tests__/moduleManifest.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import mongoose from 'mongoose';
 import Module from '../../models/Module';
-import { validateManifest, ModuleManifest } from '../moduleManifest';
+import { validateManifest, ModuleManifest, approveManifest } from '../moduleManifest';
 import SchemaDefinition from '../../services/schemaRegistry/schemaDefinition.model';
 
 // Helper to run Mongoose pre-save hooks without DB
@@ -119,6 +119,24 @@ describe('ModuleSchema pre-save', () => {
       endpoints: { rest: '/api/inventory' },
     });
     await assert.rejects(runPreSave(mod), /Invalid module manifest/);
+  });
+});
+
+describe('approveManifest schema key mismatch', () => {
+  it('rejects manifest when key differs from $id and persists by $id', async () => {
+    let captured: any = null;
+    (SchemaDefinition as any).updateOne = async (query: any) => {
+      captured = query;
+    };
+    const manifest: ModuleManifest = {
+      name: 'inventory',
+      version: '1.0.0',
+      endpoints: { rest: '/api' },
+      schemas: { wrong: { $id: 'right', type: 'object' } },
+    };
+    const result = await approveManifest(manifest);
+    assert.equal(result, false);
+    assert.equal(captured.schemaId, 'right');
   });
 });
 

--- a/src/lib/__tests__/moduleManifest.test.ts
+++ b/src/lib/__tests__/moduleManifest.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import mongoose from 'mongoose';
 import Module from '../../models/Module';
 import { validateManifest, ModuleManifest } from '../moduleManifest';
+import SchemaDefinition from '../../services/schemaRegistry/schemaDefinition.model';
 
 // Helper to run Mongoose pre-save hooks without DB
 function runPreSave(doc: any) {
@@ -79,6 +80,9 @@ describe('validateManifest', () => {
     assert.equal(validateManifest(manifest), false);
   });
 });
+
+// Stub schema registry to avoid DB interactions during tests
+(SchemaDefinition as any).updateOne = async () => {};
 
 describe('ModuleSchema pre-save', () => {
   it('allows saving with valid manifest', async () => {

--- a/src/lib/moduleManifest.ts
+++ b/src/lib/moduleManifest.ts
@@ -1,4 +1,5 @@
 import Ajv, { JSONSchemaType } from 'ajv';
+import SchemaDefinition from '../services/schemaRegistry/schemaDefinition.model';
 
 export interface ModuleManifest {
   name: string;
@@ -87,3 +88,21 @@ const ajv = new Ajv({ allErrors: true });
  * validation feedback actionable.
  */
 export const validateManifest = ajv.compile(manifestSchema);
+
+export async function approveManifest(manifest: ModuleManifest): Promise<boolean> {
+  const valid = validateManifest(manifest);
+  if (!valid) {
+    return false;
+  }
+  const schemas = Object.values(manifest.schemas || {});
+  for (const schema of schemas) {
+    if (schema.$id) {
+      await SchemaDefinition.updateOne(
+        { schemaId: schema.$id, version: manifest.version },
+        { schemaId: schema.$id, version: manifest.version, schema },
+        { upsert: true }
+      );
+    }
+  }
+  return true;
+}

--- a/src/lib/moduleManifest.ts
+++ b/src/lib/moduleManifest.ts
@@ -94,9 +94,14 @@ export async function approveManifest(manifest: ModuleManifest): Promise<boolean
   if (!valid) {
     return false;
   }
-  const schemas = Object.values(manifest.schemas || {});
-  for (const schema of schemas) {
+  const schemas = Object.entries(manifest.schemas || {});
+  let mismatch = false;
+  for (const [key, schema] of schemas) {
     if (schema.$id) {
+      if (key !== schema.$id) {
+        mismatch = true;
+        console.warn(`Schema key "${key}" does not match $id "${schema.$id}"`);
+      }
       await SchemaDefinition.updateOne(
         { schemaId: schema.$id, version: manifest.version },
         { schemaId: schema.$id, version: manifest.version, schema },
@@ -104,5 +109,5 @@ export async function approveManifest(manifest: ModuleManifest): Promise<boolean
       );
     }
   }
-  return true;
+  return mismatch ? false : true;
 }

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -1,6 +1,6 @@
 import mongoose, { Schema, Document, models } from 'mongoose';
 import mongoosePaginate from 'mongoose-paginate-v2';
-import { ModuleManifest, validateManifest } from '../lib/moduleManifest';
+import { ModuleManifest, approveManifest } from '../lib/moduleManifest';
 
 export interface IModule extends Document {
   name: string;
@@ -28,8 +28,8 @@ const ModuleSchema: Schema = new Schema({
 }, { timestamps: true });
 
 // Validate module manifest
-ModuleSchema.pre('save', function(next) {
-  if (!validateManifest(this.manifest as ModuleManifest)) {
+ModuleSchema.pre('save', async function(next) {
+  if (!(await approveManifest(this.manifest as ModuleManifest))) {
     return next(new Error('Invalid module manifest'));
   }
   next();

--- a/src/services/schemaRegistry/__tests__/schemaRegistry.controller.test.ts
+++ b/src/services/schemaRegistry/__tests__/schemaRegistry.controller.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { GET, POST } from '../schemaRegistry.controller';
+import SchemaDefinition from '../schemaDefinition.model';
+
+// In-memory store to mock database operations
+const store: any[] = [];
+(SchemaDefinition as any).create = async (doc: any) => {
+  store.push(doc);
+  return doc;
+};
+(SchemaDefinition as any).find = async () => store;
+
+describe('schemaRegistry.controller', () => {
+  it('creates and retrieves schemas', async () => {
+    const reqPost = new Request('http://test/schemas', {
+      method: 'POST',
+      body: JSON.stringify({ $id: 'test-schema', version: '1.0.0', schema: { type: 'object' } }),
+    });
+    const resPost = await POST(reqPost);
+    assert.equal(resPost.status, 201);
+
+    const reqGet = new Request('http://test/schemas');
+    const resGet = await GET(reqGet);
+    const data = await resGet.json();
+    assert.equal(Array.isArray(data), true);
+    assert.equal(data.length, 1);
+    assert.equal(data[0].schemaId, 'test-schema');
+  });
+});

--- a/src/services/schemaRegistry/schemaDefinition.model.ts
+++ b/src/services/schemaRegistry/schemaDefinition.model.ts
@@ -1,0 +1,17 @@
+import mongoose, { Schema, models } from 'mongoose';
+
+export interface ISchemaDefinition {
+  schemaId: string;
+  version: string;
+  schema: Record<string, any>;
+}
+
+const SchemaDefinitionSchema = new Schema<ISchemaDefinition>({
+  schemaId: { type: String, required: true },
+  version: { type: String, required: true },
+  schema: { type: Schema.Types.Mixed, required: true },
+}, { timestamps: true });
+
+SchemaDefinitionSchema.index({ schemaId: 1, version: 1 }, { unique: true });
+
+export default models.SchemaDefinition || mongoose.model<ISchemaDefinition>('SchemaDefinition', SchemaDefinitionSchema);

--- a/src/services/schemaRegistry/schemaRegistry.controller.ts
+++ b/src/services/schemaRegistry/schemaRegistry.controller.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import SchemaDefinition from './schemaDefinition.model';
+
+export async function GET(_req: Request) {
+  const schemas = await SchemaDefinition.find();
+  return NextResponse.json(schemas);
+}
+
+export async function POST(req: Request) {
+  const { $id, version, schema } = await req.json();
+  if (!$id || !version || !schema) {
+    return NextResponse.json({ message: 'Invalid payload' }, { status: 400 });
+  }
+  const doc = await SchemaDefinition.create({ schemaId: $id, version, schema });
+  return NextResponse.json(doc, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- add schema registry controller with GET/POST endpoints
- store schema definitions with id and version
- upload module schemas to registry when manifests are approved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899872255f883339c7aeba5b2ce3595