### PR TITLE
docs: add messaging patterns and broker wrapper

### DIFF
--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -1,0 +1,15 @@
+# Messaging Patterns
+
+This document outlines recommended messaging patterns for distributed systems.
+
+## Publish/Subscribe
+
+In the **pub/sub** model, producers publish events to a topic without knowledge of the consumers. Subscribers express interest in specific topics and receive relevant events. This pattern enables loose coupling and horizontal scaling.
+
+## Command
+
+A **command** conveys an explicit request for an action. Unlike events, commands target a single receiver that is responsible for handling the request. Use commands when you need strict control flow or acknowledgement from a specific service.
+
+## Saga
+
+A **saga** coordinates a long‑running transaction across multiple services using a series of local transactions and compensating actions. Each step publishes events or commands that trigger the next step. If a step fails, compensating commands roll back previous actions to maintain consistency.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js && rm -rf .tmp-tests"
+    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts src/lib/broker.ts src/lib/broker.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js .tmp-tests/lib/broker.test.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",

--- a/src/lib/broker.test.ts
+++ b/src/lib/broker.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import Broker from './broker';
+
+// Tests for Broker behaviors
+
+describe('Broker', () => {
+  it('delivers messages to subscribers', async () => {
+    const broker = new Broker();
+    const payload = { value: 42 };
+    let received: any;
+
+    broker.subscribe('topic', (msg) => {
+      received = msg;
+    });
+
+    await broker.publish('topic', payload);
+    assert.deepEqual(received, payload);
+  });
+
+  it('resolves publish promise when async handler acknowledges', async (t: TestContext) => {
+    const broker = new Broker();
+    let handled = false;
+
+    t.mock.timers.enable();
+
+    broker.subscribe('async', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      handled = true;
+    });
+
+    const publishPromise = broker.publish('async', 'data');
+    t.mock.timers.tick(10);
+    await publishPromise;
+    assert.equal(handled, true);
+  });
+
+  it('retries handler on failure up to maxRetries', async (t: TestContext) => {
+    const broker = new Broker({ maxRetries: 2, retryDelayMs: 100 });
+    let attempts = 0;
+
+    t.mock.timers.enable();
+
+    broker.subscribe('retry', () => {
+      attempts += 1;
+      if (attempts <= 2) {
+        throw new Error('fail');
+      }
+    });
+
+    const publishPromise = broker.publish('retry', 'payload');
+    assert.equal(attempts, 1);
+
+    t.mock.timers.tick(100); // first retry
+    assert.equal(attempts, 2);
+
+    t.mock.timers.tick(100); // second retry, should succeed
+    await publishPromise;
+    assert.equal(attempts, 3);
+  });
+
+  it('sends message to DLQ after exceeding retries', async (t: TestContext) => {
+    const broker = new Broker({ maxRetries: 1, retryDelayMs: 100 });
+    let dlqPayload: any;
+    let dlqError: unknown;
+    let attempts = 0;
+
+    t.mock.timers.enable();
+
+    broker.subscribe('fail', () => {
+      attempts += 1;
+      throw new Error('boom');
+    });
+
+    broker.onDeadLetter('fail', (payload, error) => {
+      dlqPayload = payload;
+      dlqError = error;
+    });
+
+    const publishPromise = broker.publish('fail', 'task');
+    t.mock.timers.tick(100); // retry
+    await publishPromise;
+
+    assert.equal(attempts, 2); // initial + 1 retry
+    assert.equal(dlqPayload, 'task');
+    assert(dlqError instanceof Error);
+  });
+});
+

--- a/src/lib/broker.ts
+++ b/src/lib/broker.ts
@@ -1,0 +1,101 @@
+import { EventEmitter } from "events";
+import { randomUUID } from "crypto";
+
+/**
+ * Configuration options for {@link Broker}.
+ */
+interface BrokerOptions {
+  /**
+   * Maximum number of times a failing handler will be retried before the
+   * message is forwarded to the dead-letter queue. Defaults to `3`.
+   */
+  maxRetries?: number;
+  /**
+   * Delay in milliseconds before attempting to process a failed message
+   * again. Defaults to `1000` ms.
+   */
+  retryDelayMs?: number;
+}
+
+type Handler<T> = (payload: T) => Promise<void> | void;
+
+interface Message<T> {
+  id: string;
+  payload: T;
+  attempt: number;
+  resolve: () => void;
+}
+
+/**
+ * Simple in-memory message broker that supports acknowledgements, retries and
+ * a dead-letter queue.
+ *
+ * This implementation is intended for lightweight, single-process scenarios
+ * such as tests or local development. Messages are kept only in memory and the
+ * broker does not provide any concurrency guarantees beyond Node's event loop;
+ * it should not be used across multiple processes or where durability is
+ * required.
+ */
+class Broker {
+  private emitter = new EventEmitter();
+  private maxRetries: number;
+  private retryDelay: number;
+
+  constructor(options: BrokerOptions = {}) {
+    this.maxRetries = options.maxRetries ?? 3;
+    this.retryDelay = options.retryDelayMs ?? 1000;
+  }
+
+  /**
+   * Publish a message to a topic and wait for it to be acknowledged.
+   */
+  publish<T>(topic: string, payload: T): Promise<void> {
+    return new Promise((resolve) => {
+      const msg: Message<T> = {
+        id: randomUUID(),
+        payload,
+        attempt: 0,
+        resolve,
+      };
+      this.emitter.emit(topic, msg);
+    });
+  }
+
+  /**
+   * Subscribe to a topic with a handler that processes incoming messages.
+   *
+   * The handler can be synchronous or return a promise. Any exception thrown
+   * or promise rejection is captured and will cause the message to be retried
+   * until {@link BrokerOptions.maxRetries} is reached. When the retry limit is
+   * exceeded, the message is forwarded to the dead-letter queue and the error
+   * is passed to registered {@link onDeadLetter} handlers.
+   */
+  subscribe<T>(topic: string, handler: Handler<T>): void {
+    this.emitter.on(topic, async (msg: Message<T>) => {
+      try {
+        await handler(msg.payload);
+        msg.resolve();
+      } catch (err) {
+        if (msg.attempt >= this.maxRetries) {
+          this.emitter.emit(`${topic}:dlq`, msg.payload, err);
+          msg.resolve();
+          return;
+        }
+        const retry: Message<T> = {
+          ...msg,
+          attempt: msg.attempt + 1,
+        };
+        setTimeout(() => this.emitter.emit(topic, retry), this.retryDelay);
+      }
+    });
+  }
+
+  /**
+   * Listen for messages that ended up in the dead‑letter queue for a topic.
+   */
+  onDeadLetter<T>(topic: string, handler: (payload: T, error: unknown) => void): void {
+    this.emitter.on(`${topic}:dlq`, handler);
+  }
+}
+
+export default Broker;

--- a/src/modules/example/index.ts
+++ b/src/modules/example/index.ts
@@ -1,0 +1,25 @@
+import Broker from "../../lib/broker";
+
+// Create a broker with one retry before moving messages to the dead‑letter queue.
+const broker = new Broker({ maxRetries: 1, retryDelayMs: 50 });
+
+// Basic publish/subscribe usage.
+broker.subscribe("greeting", async (payload: { text: string }) => {
+  console.warn("received:", payload.text);
+});
+
+// Demonstrate retries and DLQ handling.
+broker.subscribe("task", async () => {
+  throw new Error("fail");
+});
+
+broker.onDeadLetter("task", (payload) => {
+  console.error("moved to DLQ:", payload);
+});
+
+async function main() {
+  await broker.publish("greeting", { text: "hello" });
+  await broker.publish("task", { id: 1 });
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- document recommended messaging patterns
- implement in-memory broker with ack, retry and DLQ support
- add example module demonstrating publish/subscribe and dead-letter handling
- add tests covering broker publish, retry, DLQ handling and promise resolution
- expand broker JSDoc to describe options, usage limits and error propagation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998725347083338ddd78bc56960254