### PR TITLE
feat: add module scopes and API middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,15 @@ El **Módulo Central** gestiona:
 
 - `GET /api/auditLogs`         – Consultar logs de operaciones
 
+## 🔐 Scopes de Módulos
+
+Los módulos registrados pueden declarar un arreglo `scopes` con los permisos que tienen habilitados.
+Un middleware para todas las rutas bajo `/api` verifica que el módulo que realiza la solicitud
+esté identificado mediante el encabezado `X-Module-Id` y que posea todos los scopes indicados en
+`X-Module-Scopes`.
+
+Consulta [docs/security.md](./docs/security.md) para más detalles sobre la configuración y uso de scopes.
+
 ---
 
 ## 🛠️ Comandos Útiles

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,25 @@
+# Seguridad y Scopes de Módulos
+
+Los módulos registrados en **CoreFoundry** ahora incluyen un campo `scopes` que define los permisos disponibles para cada módulo.
+Los scopes representan acciones autorizadas (por ejemplo, `auth:login`, `inventory:read`).
+
+## Encabezados requeridos
+
+Toda petición a rutas bajo `/api` debe incluir los siguientes encabezados:
+
+- `X-Module-Id`: Identificador del módulo que realiza la solicitud.
+- `X-Module-Scopes`: Lista separada por comas con los scopes necesarios para la operación.
+
+El middleware verifica que el módulo exista y que todos los scopes solicitados estén permitidos. Si falta alguno de los encabezados
+obligatorios o si el módulo no posee los scopes requeridos, la solicitud se rechaza con los códigos `401` o `403` según corresponda.
+
+## Ejemplo
+
+```http
+POST /api/auth/login
+X-Module-Id: 64fae1...
+X-Module-Scopes: auth:login
+```
+
+Si el módulo `64fae1...` incluye `auth:login` en su arreglo de `scopes`, la solicitud será procesada normalmente.
+De lo contrario, el middleware responderá con un mensaje de error e impedirá la ejecución del handler.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,2 +1,13 @@
-export { auth as middleware } from "@/auth";
+import { NextRequest } from 'next/server';
+import { auth } from '@/auth';
+import { verifyModuleScopes } from '@/app/api/middleware';
+
+export async function middleware(request: NextRequest) {
+  auth();
+  return verifyModuleScopes(request);
+}
+
+export const config = {
+  matcher: ['/api/:path*'],
+};
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js && rm -rf .tmp-tests"
+    "test": "rm -rf .tmp-tests && tsc src/lib/moduleManifest.ts src/models/Module.ts src/lib/__tests__/moduleManifest.test.ts src/app/api/middleware.ts src/app/api/__tests__/verifyModuleScopes.test.ts src/lib/mongodb.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js .tmp-tests/app/api/__tests__/verifyModuleScopes.test.js && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",

--- a/src/app/api/__tests__/verifyModuleScopes.test.ts
+++ b/src/app/api/__tests__/verifyModuleScopes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+import Module from '../../../models/Module';
+import { verifyModuleScopes } from '../middleware';
+
+process.env.MONGODB_URI = 'mongodb://localhost/test';
+mock.method(mongoose, 'connect', async () => mongoose as any);
+
+function makeRequest(headers: Record<string, string> = {}) {
+  const store: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    store[k.toLowerCase()] = v;
+  }
+  return {
+    headers: {
+      get: (key: string) => store[key.toLowerCase()] ?? null,
+    },
+  } as any;
+}
+
+describe('verifyModuleScopes', () => {
+  it('returns 401 when X-Module-Id is missing', async () => {
+    const res = await verifyModuleScopes(makeRequest());
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 404 for invalid module id', async (t) => {
+    t.mock.method(Module, 'findById', async () => { throw new Error('CastError'); });
+    const res = await verifyModuleScopes(makeRequest({
+      'x-module-id': 'invalid',
+      'x-module-scopes': 'auth:login',
+    }));
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 404 when module does not exist', async (t) => {
+    t.mock.method(Module, 'findById', async () => null);
+    const res = await verifyModuleScopes(makeRequest({
+      'x-module-id': new mongoose.Types.ObjectId().toString(),
+      'x-module-scopes': 'auth:login',
+    }));
+    assert.equal(res.status, 404);
+  });
+
+  it('returns 401 when X-Module-Scopes is missing', async (t) => {
+    t.mock.method(Module, 'findById', async () => ({ scopes: ['auth:login'] }));
+    const res = await verifyModuleScopes(makeRequest({
+      'x-module-id': new mongoose.Types.ObjectId().toString(),
+    }));
+    assert.equal(res.status, 401);
+  });
+
+  it('returns 403 when required scopes are missing', async (t) => {
+    t.mock.method(Module, 'findById', async () => ({ scopes: [] }));
+    const res = await verifyModuleScopes(makeRequest({
+      'x-module-id': new mongoose.Types.ObjectId().toString(),
+      'x-module-scopes': 'auth:login',
+    }));
+    assert.equal(res.status, 403);
+  });
+
+  it('allows request when scopes are satisfied', async (t) => {
+    t.mock.method(Module, 'findById', async () => ({ scopes: ['auth:login'] }));
+    const res = await verifyModuleScopes(makeRequest({
+      'x-module-id': new mongoose.Types.ObjectId().toString(),
+      'x-module-scopes': 'auth:login',
+    }));
+    assert.equal(res.status, 200);
+  });
+});

--- a/src/app/api/middleware.ts
+++ b/src/app/api/middleware.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import dbConnect from '../../lib/mongodb';
+import Module from '../../models/Module';
+
+export async function verifyModuleScopes(request: NextRequest): Promise<NextResponse> {
+  await dbConnect();
+  const moduleId = request.headers.get('x-module-id');
+  if (!moduleId) {
+    return NextResponse.json({ message: 'X-Module-Id header required' }, { status: 401 });
+  }
+  let mod;
+  try {
+    mod = await Module.findById(moduleId);
+  } catch {
+    return NextResponse.json({ message: 'Module not found' }, { status: 404 });
+  }
+  if (!mod) {
+    return NextResponse.json({ message: 'Module not found' }, { status: 404 });
+  }
+  const requiredHeader = request.headers.get('x-module-scopes');
+  if (!requiredHeader) {
+    return NextResponse.json({ message: 'X-Module-Scopes header required' }, { status: 401 });
+  }
+  const requiredScopes = requiredHeader.split(',').map(s => s.trim()).filter(Boolean);
+  const hasScopes = requiredScopes.every(scope => mod.scopes.includes(scope));
+  if (!hasScopes) {
+    return NextResponse.json({ message: 'Insufficient module scopes' }, { status: 403 });
+  }
+  return NextResponse.next();
+}

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -12,6 +12,10 @@ export interface IModule extends Document {
     rest: string;
     ws?: string;
   };
+  /**
+   * Scopes granted to this module for API authorization checks.
+   */
+  scopes: string[];
 }
 
 const ModuleSchema: Schema = new Schema({
@@ -24,6 +28,7 @@ const ModuleSchema: Schema = new Schema({
     rest: { type: String, required: true },
     ws: { type: String },
   },
+  scopes: { type: [String], default: [] },
   deletedAt: Date,
 }, { timestamps: true });
 


### PR DESCRIPTION
## Summary
- extend module schema with scopes field
- enforce module scope checking for all `/api` routes
- document scope headers and security requirements
- add tests covering module scope verification edge cases
- clarify purpose of module scopes with inline documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689987278f448333ab53811ad12c5914