### PR TITLE
feat: add module initialization CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ El **Módulo Central** gestiona:
 - **Build producción**: `npm run build && npm start`  
 - **Lint**: `npm run lint`  
 - **Tests**: `npm run test`  
+- **CLI de Módulos**: `npx module-cli init <nombre>` – crea la estructura base de un módulo [guía](./docs/module-cli.md)
 
 ---
 

--- a/docs/module-cli.md
+++ b/docs/module-cli.md
@@ -1,0 +1,14 @@
+# module-cli
+
+CLI para crear la estructura básica de un módulo.
+
+## Uso
+
+```bash
+npx module-cli init <nombre>
+```
+
+Esto genera:
+
+- `module.manifest.json` con metadatos base.
+- Directorios `api/`, `schemas/`, `events/` y `tests/`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.4.5",
+        "module-cli": "file:packages/module-cli",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -4990,6 +4991,10 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/module-cli": {
+      "resolved": "packages/module-cli",
+      "link": true
+    },
     "node_modules/mongodb": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.18.0.tgz",
@@ -6879,6 +6884,13 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "packages/module-cli": {
+      "version": "0.1.0",
+      "dev": true,
+      "bin": {
+        "module-cli": "index.js"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.4.5",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "module-cli": "file:packages/module-cli"
   }
 }

--- a/packages/module-cli/index.js
+++ b/packages/module-cli/index.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const [, , cmd, name] = process.argv;
+
+function usage() {
+  console.log('Usage: module-cli init <name>');
+}
+
+if (cmd !== 'init' || !name) {
+  usage();
+  process.exit(1);
+}
+
+const targetDir = path.resolve(process.cwd(), name);
+
+if (!fs.existsSync(targetDir)) {
+  fs.mkdirSync(targetDir, { recursive: true });
+}
+
+['api', 'schemas', 'events', 'tests'].forEach((folder) => {
+  fs.mkdirSync(path.join(targetDir, folder), { recursive: true });
+});
+
+const manifest = {
+  name,
+  version: '1.0.0',
+  endpoints: {},
+  schemas: {},
+  events: { publish: [], subscribe: [] }
+};
+
+fs.writeFileSync(
+  path.join(targetDir, 'module.manifest.json'),
+  JSON.stringify(manifest, null, 2)
+);
+
+console.log(`Module '${name}' initialized at ${targetDir}`);
+

--- a/packages/module-cli/package.json
+++ b/packages/module-cli/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "module-cli",
+  "version": "0.1.0",
+  "bin": {
+    "module-cli": "index.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add `module-cli` package with `init` command to scaffold new modules
- document CLI usage and link from README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998729f5a483338d7d3a8e69a50964