### PR TITLE
feat: validate and version module manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,32 @@ Cada módulo debe proporcionar un **manifest** JSON con metadatos clave (nombre,
 }
 ```
 
+### Flujo de registro y actualización
+
+1. El módulo envía su manifest al endpoint de registro del Módulo Central.
+2. El manifest se valida con `moduleManifestSchema` mediante AJV.
+3. Si es válido, se persiste y se agrega una entrada en `manifestHistory` con la versión.
+4. Para actualizar, el módulo envía un nuevo manifest con versión incrementada y el proceso se repite.
+
+#### Ejemplo de actualización
+
+```json
+{
+  "name": "inventory",
+  "version": "1.1.0",
+  "endpoints": {
+    "rest": "https://inventory.local/api",
+    "ws": "wss://inventory.local/ws"
+  },
+  "schemas": { "product": { "$id": "#/product", "type": "object" } },
+  "dependencies": ["sales"],
+  "events": {
+    "publish": ["stock.updated"],
+    "subscribe": ["order.created"]
+  }
+}
+```
+
 ### Validación y manejo de errores
 
 `validateManifest` devuelve `false` si el manifest no cumple el contrato y

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useAuthStore } from '@/store/authStore';
+import { useAuthStore } from '../store/authStore';
 import { useRouter } from 'next/navigation';
 
 interface Credentials {

--- a/src/lib/__tests__/moduleManifest.test.ts
+++ b/src/lib/__tests__/moduleManifest.test.ts
@@ -2,7 +2,8 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import mongoose from 'mongoose';
 import Module from '../../models/Module';
-import { validateManifest, ModuleManifest, approveManifest } from '../moduleManifest';
+import { validateManifest, approveManifest } from '../moduleManifest';
+import { ModuleManifest } from '../moduleManifestSchema';
 import SchemaDefinition from '../../services/schemaRegistry/schemaDefinition.model';
 
 // Helper to run Mongoose pre-save hooks without DB

--- a/src/lib/moduleManifest.ts
+++ b/src/lib/moduleManifest.ts
@@ -1,60 +1,9 @@
-import Ajv, { JSONSchemaType } from 'ajv';
+import Ajv from 'ajv';
 import SchemaDefinition from '../services/schemaRegistry/schemaDefinition.model';
-
-export interface ModuleManifest {
-  name: string;
-  version: string;
-  description?: string;
-  endpoints: {
-    rest: string;
-    ws?: string;
-  };
-  schemas: Record<string, any>;
-  dependencies?: string[];
-  events?: {
-    publish?: string[];
-    subscribe?: string[];
-  };
-}
-
-// JSON Schema definition describing the shape of a module manifest.
-// The schema is used by AJV to validate manifests at runtime and lists
-// all required fields along with optional ones like `dependencies` or
-// `events`.
-const manifestSchema: JSONSchemaType<ModuleManifest> = {
-  type: 'object',
-  properties: {
-    name: { type: 'string' },
-    version: { type: 'string' },
-    description: { type: 'string', nullable: true },
-    endpoints: {
-      type: 'object',
-      properties: {
-        rest: { type: 'string' },
-        ws: { type: 'string', nullable: true },
-      },
-      required: ['rest'],
-      additionalProperties: false,
-    },
-    schemas: { type: 'object', additionalProperties: true },
-    dependencies: {
-      type: 'array',
-      items: { type: 'string' },
-      nullable: true,
-    },
-    events: {
-      type: 'object',
-      properties: {
-        publish: { type: 'array', items: { type: 'string' }, nullable: true },
-        subscribe: { type: 'array', items: { type: 'string' }, nullable: true },
-      },
-      additionalProperties: false,
-      nullable: true,
-    },
-  },
-  required: ['name', 'version', 'endpoints', 'schemas'],
-  additionalProperties: false,
-};
+import {
+  moduleManifestSchema,
+  type ModuleManifest,
+} from './moduleManifestSchema';
 
 // Configure AJV to collect all validation errors instead of stopping after the
 // first one. This produces more actionable feedback for developers.
@@ -87,7 +36,7 @@ const ajv = new Ajv({ allErrors: true });
  * message. Presenting distilled messages instead of raw AJV objects helps keep
  * validation feedback actionable.
  */
-export const validateManifest = ajv.compile(manifestSchema);
+export const validateManifest = ajv.compile(moduleManifestSchema);
 
 export async function approveManifest(manifest: ModuleManifest): Promise<boolean> {
   const valid = validateManifest(manifest);

--- a/src/lib/moduleManifestSchema.ts
+++ b/src/lib/moduleManifestSchema.ts
@@ -1,0 +1,53 @@
+import { JSONSchemaType } from 'ajv';
+
+export interface ModuleManifest {
+  name: string;
+  version: string;
+  endpoints: {
+    rest: string;
+    ws?: string;
+  };
+  events?: {
+    publish?: string[];
+    subscribe?: string[];
+  };
+  schemas: Record<string, any>;
+  dependencies?: string[];
+  description?: string;
+}
+
+export const moduleManifestSchema: JSONSchemaType<ModuleManifest> = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    version: { type: 'string' },
+    description: { type: 'string', nullable: true },
+    endpoints: {
+      type: 'object',
+      properties: {
+        rest: { type: 'string' },
+        ws: { type: 'string', nullable: true },
+      },
+      required: ['rest'],
+      additionalProperties: false,
+    },
+    events: {
+      type: 'object',
+      properties: {
+        publish: { type: 'array', items: { type: 'string' }, nullable: true },
+        subscribe: { type: 'array', items: { type: 'string' }, nullable: true },
+      },
+      additionalProperties: false,
+      nullable: true,
+    },
+    schemas: { type: 'object', additionalProperties: true },
+    dependencies: {
+      type: 'array',
+      items: { type: 'string' },
+      nullable: true,
+    },
+  },
+  required: ['name', 'version', 'endpoints', 'schemas'],
+  additionalProperties: false,
+};
+

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Document, models } from 'mongoose';
 import mongoosePaginate from 'mongoose-paginate-v2';
-import { ModuleManifest, approveManifest } from '../lib/moduleManifest';
+import { ModuleManifest } from '../lib/moduleManifestSchema';
+import { approveManifest } from '../lib/moduleManifest';
 
 export interface IModule extends Document {
   name: string;
@@ -12,6 +13,11 @@ export interface IModule extends Document {
     rest: string;
     ws?: string;
   };
+  manifestHistory?: {
+    version: string;
+    manifest: ModuleManifest;
+    createdAt: Date;
+  }[];
   /** Scopes granted to this module for API authorization checks. */
   scopes: string[];
   status: 'online' | 'offline';
@@ -26,6 +32,16 @@ const ModuleSchema: Schema = new Schema(
     description: { type: String, default: '' },
     ownerId: { type: Schema.Types.ObjectId, ref: 'User', required: true },
     manifest: { type: Schema.Types.Mixed, required: true },
+    manifestHistory: {
+      type: [
+        {
+          version: { type: String, required: true },
+          manifest: { type: Schema.Types.Mixed, required: true },
+          createdAt: { type: Date, default: Date.now },
+        },
+      ],
+      default: [],
+    },
     endpoints: {
       rest: { type: String, required: true },
       ws: { type: String },
@@ -41,8 +57,22 @@ const ModuleSchema: Schema = new Schema(
 
 // Validate module manifest
 ModuleSchema.pre('save', async function (next) {
-  if (!(await approveManifest(this.manifest as ModuleManifest))) {
+  const doc = this as unknown as IModule;
+  if (!(await approveManifest(doc.manifest as ModuleManifest))) {
     return next(new Error('Invalid module manifest'));
+  }
+  if (!doc.manifestHistory) {
+    doc.manifestHistory = [];
+  }
+  const exists = doc.manifestHistory.some(
+    (m) => m.version === doc.version
+  );
+  if (!exists) {
+    doc.manifestHistory.push({
+      version: doc.version,
+      manifest: doc.manifest,
+      createdAt: new Date(),
+    });
   }
   next();
 });


### PR DESCRIPTION
## Summary
- extract module manifest schema into dedicated file and validate with AJV
- persist manifest snapshots and version history on Module documents
- document module registration and update flow with manifest example

## Testing
- `npm test` *(fails: Could not find '/workspace/CoreFoundry/.tmp-tests/**/*.test.js')*
- `tsc src/lib/moduleManifest.ts src/lib/moduleManifestSchema.ts src/lib/__tests__/moduleManifest.test.ts src/models/Module.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-tests/lib/__tests__/moduleManifest.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689999e654588333952218b136ea5ebf