### PR TITLE
feat: add module discovery service

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,16 @@ Cada módulo debe proporcionar un **manifest** JSON con metadatos clave (nombre,
 }
 ```
 
+### Registro y descubrimiento de módulos
+
+Los módulos se integran con el Módulo Central registrando su manifest a
+través del endpoint `POST /api/modules/register`. La respuesta incluye un
+`integrationToken` que identifica al módulo en futuras interacciones.
+
+Para consultar los módulos disponibles y su metadata básica, se expone el
+endpoint `GET /api/modules`, que devuelve un listado con todos los módulos
+registrados.
+
 ### Validación y manejo de errores
 
 `validateManifest` devuelve `false` si el manifest no cumple el contrato y

--- a/src/app/api/modules/register/route.ts
+++ b/src/app/api/modules/register/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
-import Module from '@/models/Module';
+import { registerModule } from '@/services/moduleDiscovery';
 import { z } from 'zod';
 
 const registerSchema = z.object({
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
       // Module unreachable, keep status offline
     }
 
-    const module = await Module.create({
+    const { module, integrationToken } = await registerModule({
       ...data,
       status,
       lastHandshake,
@@ -73,6 +73,7 @@ export async function POST(req: Request) {
       {
         status: 'registered',
         moduleId: module._id,
+        integrationToken,
         online: status === 'online',
         message:
           status === 'online'

--- a/src/app/api/modules/route.ts
+++ b/src/app/api/modules/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import { getModules } from '@/services/moduleDiscovery';
+
+export async function GET() {
+  await dbConnect();
+  const modules = await getModules();
+  return NextResponse.json(modules);
+}

--- a/src/lib/__tests__/moduleManifest.test.ts
+++ b/src/lib/__tests__/moduleManifest.test.ts
@@ -100,6 +100,7 @@ describe('ModuleSchema pre-save', () => {
       ownerId: new mongoose.Types.ObjectId(),
       manifest,
       endpoints: { rest: '/api/inventory' },
+      integrationToken: 'token',
     });
     await runPreSave(mod); // should not throw
   });
@@ -118,6 +119,7 @@ describe('ModuleSchema pre-save', () => {
       ownerId: new mongoose.Types.ObjectId(),
       manifest,
       endpoints: { rest: '/api/inventory' },
+      integrationToken: 'token',
     });
     await assert.rejects(runPreSave(mod), /Invalid module manifest/);
   });

--- a/src/models/Module.ts
+++ b/src/models/Module.ts
@@ -13,6 +13,8 @@ export interface IModule extends Document {
     rest: string;
     ws?: string;
   };
+  /** Token utilizado para autenticar integraciones entre módulos. */
+  integrationToken: string;
   manifestHistory?: {
     version: string;
     manifest: ModuleManifest;
@@ -46,6 +48,7 @@ const ModuleSchema: Schema = new Schema(
       rest: { type: String, required: true },
       ws: { type: String },
     },
+    integrationToken: { type: String, required: true },
     scopes: { type: [String], default: [] },
     status: { type: String, enum: ['online', 'offline'], default: 'offline' },
     lastHandshake: Date,

--- a/src/services/__tests__/moduleDiscovery.test.ts
+++ b/src/services/__tests__/moduleDiscovery.test.ts
@@ -1,0 +1,27 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerModule, getModules } from '../moduleDiscovery';
+import Module from '../../models/Module';
+
+const store: any[] = [];
+(Module as any).create = async (doc: any) => {
+  store.push(doc);
+  return doc;
+};
+(Module as any).find = async () => store;
+
+describe('moduleDiscovery service', () => {
+  it('registers modules and lists them', async () => {
+    const { integrationToken } = await registerModule({
+      name: 'inventory',
+      version: '1.0.0',
+      ownerId: 'u1',
+      manifest: {},
+      endpoints: { rest: 'https://inventory.local/api' },
+    });
+    assert.equal(typeof integrationToken, 'string');
+    const modules = await getModules();
+    assert.equal(modules.length, 1);
+    assert.equal(modules[0].integrationToken, integrationToken);
+  });
+});

--- a/src/services/moduleDiscovery.ts
+++ b/src/services/moduleDiscovery.ts
@@ -1,0 +1,32 @@
+import Module from '../models/Module';
+import crypto from 'crypto';
+
+export interface RegisterModuleInput {
+  name: string;
+  version: string;
+  description?: string;
+  ownerId: string;
+  manifest: any;
+  endpoints: {
+    rest: string;
+    ws?: string;
+  };
+  [key: string]: any;
+}
+
+/**
+ * Registers a module and stores its metadata in the database.
+ * Returns the created module along with a generated integration token.
+ */
+export async function registerModule(data: RegisterModuleInput) {
+  const integrationToken = crypto.randomBytes(32).toString('hex');
+  const module = await Module.create({ ...data, integrationToken });
+  return { module, integrationToken };
+}
+
+/**
+ * Retrieves the list of registered modules.
+ */
+export async function getModules() {
+  return Module.find();
+}


### PR DESCRIPTION
## Summary
- add module discovery service for module registration and discovery
- store integration tokens for modules and expose module list endpoint
- document module registration and discovery flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68999c8a2cbc8333824f6dad1ecbf255