### PR TITLE
feat: add event bus wrapper and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,24 @@ un resumen legible de todos los problemas detectados.
 - **Endpoints HTTP**: se usan para operaciones sincrónicas declaradas en el manifest.
 - **Seguridad**: los tokens y permisos se propagan entre módulos y se auditan todas las llamadas.
 
+### Event Bus
+
+La comunicación asíncrona se realiza a través de un exchange de tipo *topic*
+llamado `core.events`. Cada servicio crea su propia cola siguiendo el patrón
+`core.events.<servicio>` y la enlaza a las claves de enrutamiento de los
+eventos que consume.
+
+Los mensajes publicados deben respetar la siguiente convención:
+
+```json
+{
+  "type": "nombre.evento",
+  "payload": { "...": "" }
+}
+```
+
+`type` describe el evento y `payload` contiene los datos asociados.
+
 ---
 
 ## 🔑 Gestión de Usuarios y Subscripciones

--- a/src/messaging/__tests__/eventBus.test.ts
+++ b/src/messaging/__tests__/eventBus.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, TestContext } from 'node:test';
+import assert from 'node:assert/strict';
+import { publish, subscribe } from '../eventBus';
+
+describe('eventBus', () => {
+  it('delivers published events to subscribers', async () => {
+    const payload = { foo: 'bar' };
+    let received: any;
+
+    subscribe('test.event', (data) => {
+      received = data;
+    });
+
+    await publish('test.event', payload);
+    assert.deepEqual(received, payload);
+  });
+
+  it('resolves publish promise after async handlers', async (t: TestContext) => {
+    let handled = false;
+    t.mock.timers.enable();
+
+    subscribe('async.event', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      handled = true;
+    });
+
+    const publishPromise = publish('async.event', {});
+    t.mock.timers.tick(10);
+    await publishPromise;
+    assert.equal(handled, true);
+  });
+});

--- a/src/messaging/eventBus.ts
+++ b/src/messaging/eventBus.ts
@@ -1,0 +1,25 @@
+import Broker from "../lib/broker";
+
+export interface Event<T> {
+  type: string;
+  payload: T;
+}
+
+const broker = new Broker();
+
+/**
+ * Publish an event using the underlying Broker instance.
+ */
+export function publish<T>(type: string, payload: T): Promise<void> {
+  return broker.publish(type, payload);
+}
+
+/**
+ * Subscribe to a given event type.
+ */
+export function subscribe<T>(
+  type: string,
+  handler: (payload: T) => Promise<void> | void,
+): void {
+  broker.subscribe(type, handler);
+}


### PR DESCRIPTION
## Summary
- add event bus module that wraps Broker and exposes publish/subscribe
- document exchange/queue names and message format in README
- add integration tests for event bus

## Testing
- `tsc src/lib/broker.ts src/lib/broker.test.ts src/messaging/eventBus.ts src/messaging/__tests__/eventBus.test.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks`
- `node --test .tmp-tests/lib/broker.test.js .tmp-tests/messaging/__tests__/eventBus.test.js`
- `npm run lint` *(fails: Do not assign to the variable `module`)*

------
https://chatgpt.com/codex/tasks/task_e_6899a02e265c83338acac9e4a162fb7b