### PR TITLE
feat(cli): add module template and commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,23 @@ Consulta [docs/security.md](./docs/security.md) para más detalles sobre la conf
 - **Build producción**: `npm run build && npm start`  
 - **Lint**: `npm run lint`  
 - **Tests**: `npm run test`  
-- **CLI de Módulos**: `npx module-cli init <nombre>` – crea la estructura base de un módulo [guía](./docs/module-cli.md)
+- **CLI de Módulos**: `npx module-cli <comando>` – utilidades para módulos (ver [CLI de Módulos](#cli-de-módulos))
+
+## CLI de Módulos
+
+Instala la dependencia de desarrollo:
+
+```bash
+npm install --save-dev @core/module-cli
+```
+
+Comandos disponibles:
+
+```bash
+npx module-cli create <nombre>
+npx module-cli validate [directorio]
+npx module-cli test [directorio]
+```
 
 ---
 

--- a/docs/module-cli.md
+++ b/docs/module-cli.md
@@ -1,14 +1,17 @@
 # module-cli
 
-CLI para crear la estructura básica de un módulo.
+CLI para crear y gestionar módulos.
 
-## Uso
+## Instalación
 
 ```bash
-npx module-cli init <nombre>
+npm install --save-dev @core/module-cli
 ```
 
-Esto genera:
+## Comandos
 
-- `module.manifest.json` con metadatos base.
-- Directorios `api/`, `schemas/`, `events/` y `tests/`.
+```bash
+npx module-cli create <nombre>      # genera un módulo desde la plantilla
+npx module-cli validate [directorio] # valida el manifest
+npx module-cli test [directorio]     # ejecuta los tests
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.4.5",
-        "module-cli": "file:packages/module-cli",
+        "@core/module-cli": "file:packages/module-cli",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -4991,7 +4991,7 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/module-cli": {
+    "node_modules/@core/module-cli": {
       "resolved": "packages/module-cli",
       "link": true
     },
@@ -6887,6 +6887,7 @@
       }
     },
     "packages/module-cli": {
+      "name": "@core/module-cli",
       "version": "0.1.0",
       "dev": true,
       "bin": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "eslint-config-next": "15.4.5",
     "tailwindcss": "^4",
     "typescript": "^5",
-    "module-cli": "file:packages/module-cli"
+    "@core/module-cli": "file:packages/module-cli"
   }
 }

--- a/packages/module-cli/index.js
+++ b/packages/module-cli/index.js
@@ -1,40 +1,81 @@
 #!/usr/bin/env node
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('child_process');
+const yargs = require('yargs/yargs');
+const { hideBin } = require('yargs/helpers');
 
-const [, , cmd, name] = process.argv;
-
-function usage() {
-  console.log('Usage: module-cli init <name>');
+function copyTemplate(targetDir, name) {
+  const templateDir = path.resolve(__dirname, '../../templates/basic-module');
+  fs.cpSync(templateDir, targetDir, { recursive: true });
+  const manifestPath = path.join(targetDir, 'module.manifest.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  manifest.name = name;
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 }
 
-if (cmd !== 'init' || !name) {
-  usage();
-  process.exit(1);
-}
-
-const targetDir = path.resolve(process.cwd(), name);
-
-if (!fs.existsSync(targetDir)) {
-  fs.mkdirSync(targetDir, { recursive: true });
-}
-
-['api', 'schemas', 'events', 'tests'].forEach((folder) => {
-  fs.mkdirSync(path.join(targetDir, folder), { recursive: true });
-});
-
-const manifest = {
-  name,
-  version: '1.0.0',
-  endpoints: {},
-  schemas: {},
-  events: { publish: [], subscribe: [] }
-};
-
-fs.writeFileSync(
-  path.join(targetDir, 'module.manifest.json'),
-  JSON.stringify(manifest, null, 2)
-);
-
-console.log(`Module '${name}' initialized at ${targetDir}`);
-
+yargs(hideBin(process.argv))
+  .command(
+    'create <name>',
+    'Genera un módulo a partir de la plantilla básica',
+    (y) => y.positional('name', { describe: 'Nombre del módulo', type: 'string' }),
+    (argv) => {
+      const targetDir = path.resolve(process.cwd(), argv.name);
+      copyTemplate(targetDir, argv.name);
+      console.log(`Módulo '${argv.name}' creado en ${targetDir}`);
+    }
+  )
+  .command(
+    'validate [dir]',
+    'Valida el manifest de un módulo',
+    (y) =>
+      y.positional('dir', {
+        describe: 'Directorio del módulo',
+        type: 'string',
+        default: process.cwd(),
+      }),
+    (argv) => {
+      const moduleDir = path.resolve(process.cwd(), argv.dir);
+      const manifestPath = path.join(moduleDir, 'module.manifest.json');
+      if (!fs.existsSync(manifestPath)) {
+        console.error('module.manifest.json no encontrado');
+        process.exit(1);
+      }
+      try {
+        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+        if (!manifest.name || !manifest.version) {
+          throw new Error('Campos "name" y "version" requeridos');
+        }
+        console.log('Manifest válido');
+      } catch (err) {
+        console.error(`Manifest inválido: ${err.message}`);
+        process.exit(1);
+      }
+    }
+  )
+  .command(
+    'test [dir]',
+    'Ejecuta los tests de un módulo',
+    (y) =>
+      y.positional('dir', {
+        describe: 'Directorio del módulo',
+        type: 'string',
+        default: process.cwd(),
+      }),
+    (argv) => {
+      const moduleDir = path.resolve(process.cwd(), argv.dir);
+      const testsDir = path.join(moduleDir, 'tests');
+      if (!fs.existsSync(testsDir)) {
+        console.error('No se encontró el directorio de tests');
+        process.exit(1);
+      }
+      const child = spawn('node', ['--test'], {
+        cwd: testsDir,
+        stdio: 'inherit',
+        shell: true,
+      });
+      child.on('exit', (code) => process.exit(code));
+    }
+  )
+  .demandCommand(1)
+  .help().argv;

--- a/packages/module-cli/package.json
+++ b/packages/module-cli/package.json
@@ -1,7 +1,10 @@
 {
-  "name": "module-cli",
+  "name": "@core/module-cli",
   "version": "0.1.0",
   "bin": {
     "module-cli": "index.js"
+  },
+  "dependencies": {
+    "yargs": "^17.7.2"
   }
 }

--- a/templates/basic-module/api/index.js
+++ b/templates/basic-module/api/index.js
@@ -1,0 +1,3 @@
+module.exports = async function handler(req, res) {
+  res.json({ message: 'hello from module' });
+};

--- a/templates/basic-module/events/index.js
+++ b/templates/basic-module/events/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  publish: [],
+  subscribe: []
+};

--- a/templates/basic-module/module.manifest.json
+++ b/templates/basic-module/module.manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "example",
+  "version": "0.1.0",
+  "endpoints": {
+    "rest": "/api"
+  },
+  "events": {
+    "publish": [],
+    "subscribe": []
+  }
+}

--- a/templates/basic-module/tests/sample.test.js
+++ b/templates/basic-module/tests/sample.test.js
@@ -1,0 +1,6 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+test('example test', () => {
+  assert.strictEqual(1 + 1, 2);
+});


### PR DESCRIPTION
## Summary
- add `@core/module-cli` with create, validate and test commands
- scaffold basic module template
- document CLI usage in README

## Testing
- `npm test` *(fails: Could not find '/workspace/CoreFoundry/.tmp-tests/**/*.test.js')*


------
https://chatgpt.com/codex/tasks/task_e_6899a443ed80833396bcdf9a766651af