### PR TITLE
feat: add role-based dashboards

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -10,3 +10,6 @@ panel correspondiente:
 
 Cada panel utiliza un layout compartido ubicado en `src/app/dashboard/layout.tsx`
 que centraliza el diseño común antes de cargar la vista específica del rol.
+
+Los usuarios pueden acceder a su panel desde el menú de usuario (AuthMenu)
+mediante la opción **Dashboard**, disponible después de iniciar sesión.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,12 @@
+# Dashboard
+
+La ruta `/dashboard` sirve como punto de entrada para todos los paneles.
+El middleware lee el encabezado `X-User-Role` y redirige automáticamente al
+panel correspondiente:
+
+- `owner` → `/dashboard/owner`
+- `admin` → `/dashboard/admin`
+- `employee` → `/dashboard/employee`
+
+Cada panel utiliza un layout compartido ubicado en `src/app/dashboard/layout.tsx`
+que centraliza el diseño común antes de cargar la vista específica del rol.

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,13 +1,19 @@
-import { NextRequest } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/auth';
 import { verifyModulePermissions } from '@/middleware/auth';
+import { redirectDashboard } from '@/middleware/dashboard';
 
 export async function middleware(request: NextRequest) {
   auth();
-  return verifyModulePermissions(request);
+  if (request.nextUrl.pathname.startsWith('/dashboard')) {
+    return redirectDashboard(request);
+  }
+  if (request.nextUrl.pathname.startsWith('/api')) {
+    return verifyModulePermissions(request);
+  }
+  return NextResponse.next();
 }
 
 export const config = {
-  matcher: ['/api/:path*'],
+  matcher: ['/api/:path*', '/dashboard/:path*'],
 };
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "rm -rf .tmp-tests && tsc src/**/*.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test \".tmp-tests/**/*.test.js\" && rm -rf .tmp-tests"
+    "test": "rm -rf .tmp-tests && tsc src/**/*.ts --outDir .tmp-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test $(find .tmp-tests -name '*.test.js' -o -name '*.spec.js') && rm -rf .tmp-tests"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.84.1",

--- a/src/app/dashboard/AdminDashboard.tsx
+++ b/src/app/dashboard/AdminDashboard.tsx
@@ -1,0 +1,3 @@
+export default function AdminDashboard() {
+  return <div>Admin Dashboard</div>;
+}

--- a/src/app/dashboard/EmployeeDashboard.tsx
+++ b/src/app/dashboard/EmployeeDashboard.tsx
@@ -1,0 +1,3 @@
+export default function EmployeeDashboard() {
+  return <div>Employee Dashboard</div>;
+}

--- a/src/app/dashboard/OwnerDashboard.tsx
+++ b/src/app/dashboard/OwnerDashboard.tsx
@@ -1,0 +1,3 @@
+export default function OwnerDashboard() {
+  return <div>Owner Dashboard</div>;
+}

--- a/src/app/dashboard/[role]/page.tsx
+++ b/src/app/dashboard/[role]/page.tsx
@@ -1,0 +1,15 @@
+import OwnerDashboard from '../OwnerDashboard';
+import AdminDashboard from '../AdminDashboard';
+import EmployeeDashboard from '../EmployeeDashboard';
+import { Role } from '@/auth/roles';
+
+export default function DashboardPage({ params }: { params: { role: Role } }) {
+  switch (params.role) {
+    case 'owner':
+      return <OwnerDashboard />;
+    case 'admin':
+      return <AdminDashboard />;
+    default:
+      return <EmployeeDashboard />;
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react';
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return <section>{children}</section>;
+}

--- a/src/auth/permissions.ts
+++ b/src/auth/permissions.ts
@@ -1,0 +1,9 @@
+import { Role } from './roles';
+
+export type Permission = string;
+
+export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
+  owner: ['*'],
+  admin: ['manage:users', 'manage:modules'],
+  employee: ['read:basic'],
+};

--- a/src/auth/roles.ts
+++ b/src/auth/roles.ts
@@ -1,0 +1,11 @@
+export type Role = 'owner' | 'admin' | 'employee';
+
+export const DASHBOARD_PATHS: Record<Role, string> = {
+  owner: '/dashboard/owner',
+  admin: '/dashboard/admin',
+  employee: '/dashboard/employee',
+};
+
+export function getDashboardPath(role: Role): string {
+  return DASHBOARD_PATHS[role];
+}

--- a/src/components/AuthMenu.tsx
+++ b/src/components/AuthMenu.tsx
@@ -41,6 +41,13 @@ const AuthMenu = () => {
       {open && (
         <div className="absolute right-0 mt-2 w-48 bg-white text-black rounded shadow-lg z-30">
           <Link
+            href="/dashboard"
+            onClick={() => setOpen(false)}
+            className="block px-4 py-2 hover:bg-gray-100"
+          >
+            Dashboard
+          </Link>
+          <Link
             href="/profile"
             onClick={() => setOpen(false)}
             className="block px-4 py-2 hover:bg-gray-100"

--- a/src/middleware/dashboard.ts
+++ b/src/middleware/dashboard.ts
@@ -1,0 +1,11 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getDashboardPath, Role } from '../auth/roles';
+
+export function redirectDashboard(request: NextRequest): NextResponse {
+  const role = (request.headers.get('x-user-role') as Role) || 'employee';
+  const target = getDashboardPath(role);
+  if (request.nextUrl.pathname === '/dashboard') {
+    return NextResponse.redirect(new URL(target, request.url));
+  }
+  return NextResponse.next();
+}

--- a/src/services/moduleDiscovery.ts
+++ b/src/services/moduleDiscovery.ts
@@ -20,8 +20,8 @@ export interface RegisterModuleInput {
  */
 export async function registerModule(data: RegisterModuleInput) {
   const integrationToken = crypto.randomBytes(32).toString('hex');
-  const module = await Module.create({ ...data, integrationToken });
-  return { module, integrationToken };
+  const savedModule = await Module.create({ ...data, integrationToken });
+  return { module: savedModule, integrationToken };
 }
 
 /**

--- a/src/tests/authmenu.spec.ts
+++ b/src/tests/authmenu.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('AuthMenu', () => {
+  it('contains a dashboard link', () => {
+    const content = readFileSync(join(process.cwd(), 'src/components/AuthMenu.tsx'), 'utf-8');
+    assert.ok(content.includes('href="/dashboard"'));
+  });
+});

--- a/src/tests/dashboard.spec.ts
+++ b/src/tests/dashboard.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { redirectDashboard } from '../middleware/dashboard';
+import { DASHBOARD_PATHS } from '../auth/roles';
+
+function makeRequest(path: string, role: string) {
+  const url = new URL('https://example.com' + path);
+  const store: Record<string, string> = { 'x-user-role': role };
+  return {
+    nextUrl: url,
+    url: url.toString(),
+    headers: {
+      get: (key: string) => store[key.toLowerCase()] ?? null,
+    },
+  } as any;
+}
+
+describe('redirectDashboard', () => {
+  it('redirects to the path for the given role', () => {
+    const res = redirectDashboard(makeRequest('/dashboard', 'owner'));
+    assert.equal(res.headers.get('location'), 'https://example.com' + DASHBOARD_PATHS.owner);
+  });
+
+  it('does nothing when already at a role path', () => {
+    const res = redirectDashboard(makeRequest('/dashboard/admin', 'admin'));
+    assert.equal(res.headers.get('location'), null);
+  });
+});

--- a/src/tests/dashboard.test.ts
+++ b/src/tests/dashboard.test.ts
@@ -1,0 +1,1 @@
+import './dashboard.spec';


### PR DESCRIPTION
## Summary
- define role and permission utilities
- add dashboard views for owner, admin and employee
- redirect /dashboard based on role
- document dashboard routing

## Testing
- `npm test`
- `npm run lint` *(fails: Do not assign to the variable `module` in src/services/moduleDiscovery.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6899fa53db6083339db4a53101e305dd