### PR TITLE
feat: read dashboard role from session

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,8 +1,8 @@
 # Dashboard
 
 La ruta `/dashboard` sirve como punto de entrada para todos los paneles.
-El middleware lee el encabezado `X-User-Role` y redirige automáticamente al
-panel correspondiente:
+El middleware obtiene el rol desde la sesión (por ejemplo, cookie `user-role`)
+y redirige automáticamente al panel correspondiente:
 
 - `owner` → `/dashboard/owner`
 - `admin` → `/dashboard/admin`

--- a/src/middleware/dashboard.ts
+++ b/src/middleware/dashboard.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getDashboardPath, Role } from '../auth/roles';
 
 export function redirectDashboard(request: NextRequest): NextResponse {
-  const role = (request.headers.get('x-user-role') as Role) || 'employee';
+  // Obtain the role from authentication/session cookies instead of headers
+  const role = (request.cookies.get('user-role')?.value as Role) || 'employee';
   const target = getDashboardPath(role);
   if (request.nextUrl.pathname === '/dashboard') {
     return NextResponse.redirect(new URL(target, request.url));

--- a/src/tests/dashboard.spec.ts
+++ b/src/tests/dashboard.spec.ts
@@ -5,12 +5,15 @@ import { DASHBOARD_PATHS } from '../auth/roles';
 
 function makeRequest(path: string, role: string) {
   const url = new URL('https://example.com' + path);
-  const store: Record<string, string> = { 'x-user-role': role };
+  const store: Record<string, string> = { 'user-role': role };
   return {
     nextUrl: url,
     url: url.toString(),
-    headers: {
-      get: (key: string) => store[key.toLowerCase()] ?? null,
+    cookies: {
+      get: (key: string) => {
+        const value = store[key];
+        return value ? { value } : undefined;
+      },
     },
   } as any;
 }


### PR DESCRIPTION
## Summary
- derive dashboard role from `user-role` cookie instead of `X-User-Role` header
- adjust dashboard redirection tests to use cookie-based role lookup
- document session-based dashboard routing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a09b9148c8333a25ae7b557067ae2