### PR TITLE
chore: add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS
+
+Este archivo contiene instrucciones para contribuciones en el repositorio **CoreFoundry**.
+
+## Estilo y organización
+- El proyecto usa **TypeScript** con módulos ESM y el framework **Next.js**.
+- Mantén la estructura existente: componentes en `src/components`, hooks en `src/hooks`, servicios en `src/services`, etc.
+- Cuando añadas módulos, incluye un `module.manifest.json` y documentos relevantes.
+
+## Flujo de trabajo
+1. Instala dependencias si es necesario: `npm install`.
+2. Verifica el estilo: `npm run lint`.
+3. Ejecuta las pruebas: `npm test`.
+4. Documenta cambios en `docs/` y actualiza `README.md` si aplica.
+5. Registra cambios importantes en `CHANGELOG.md`.
+
+## Convenciones
+- Usa mensajes de commit en modo imperativo y concisos.
+- Acompaña nuevas funcionalidades con pruebas y documentación.
+- Revisa los lineamientos de seguridad en `docs/security.md` para cambios relacionados a permisos.
+
+## Recursos útiles
+- Arquitectura general: `README.md`.
+- CLI de módulos: `docs/module-cli.md`.
+- Mensajería y eventos: `docs/messaging.md`.
+- Dashboards y vistas: `docs/dashboard.md`.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- AGENTS guideline to record significant changes in `CHANGELOG.md`.
+
 ## [0.5.2] - 2025-08-11
 
 ### Added


### PR DESCRIPTION
## Summary
- add repository contribution guide in AGENTS.md
- note requirement to log significant changes in CHANGELOG

## Testing
- `npm test` (fails: Cannot find module 'mongoose-paginate-v2', etc.)
- `npm run lint` (fails: sh: 1: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_689a216216508333a2ba32a55c88393d