### PR TITLE
Add module orchestrator to monitor module health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - AGENTS guideline to record significant changes in `CHANGELOG.md`.
+- Module orchestrator service to monitor registered modules and prune stale entries.
 
 ## [0.5.2] - 2025-08-11
 

--- a/src/lib/auditService.ts
+++ b/src/lib/auditService.ts
@@ -1,6 +1,6 @@
-import AuditLog from '@/models/AuditLog';
-import { subscribe, EXCHANGE_NAME } from '@/lib/rabbitmq';
-import { UserRegisteredSchema } from '@/schemas/events/UserRegistered.schema';
+import AuditLog from '../models/AuditLog';
+import { subscribe, EXCHANGE_NAME } from './rabbitmq';
+import { UserRegisteredSchema } from '../schemas/events/UserRegistered.schema';
 
 let auditInitialized = false;
 

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -1,0 +1,68 @@
+import Module from '../models/Module';
+
+let interval: NodeJS.Timeout | null = null;
+
+export interface OrchestratorOptions {
+  intervalMs?: number;
+  pruneOfflineMs?: number;
+}
+
+/**
+ * Pings registered modules and updates their status.
+ * Optionally removes modules that have been offline for longer than `pruneOfflineMs`.
+ */
+export async function checkModules(pruneOfflineMs?: number) {
+  const modules = await Module.find();
+  const now = Date.now();
+
+  for (const mod of modules) {
+    const pingUrl = new URL('/ping', mod.endpoints.rest).toString();
+    let online = false;
+    try {
+      const res = await fetch(pingUrl);
+      online = res.ok;
+    } catch {
+      online = false;
+    }
+
+    if (online) {
+      await Module.findByIdAndUpdate(mod._id, {
+        status: 'online',
+        lastHandshake: new Date(),
+      });
+    } else {
+      if (
+        pruneOfflineMs &&
+        mod.lastHandshake &&
+        now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
+      ) {
+        await Module.deleteOne({ _id: mod._id });
+        continue;
+      }
+      await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+    }
+  }
+}
+
+/**
+ * Starts periodic module orchestration.
+ */
+export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
+  const { intervalMs = 60_000, pruneOfflineMs } = options;
+  if (interval) return;
+  interval = setInterval(() => {
+    checkModules(pruneOfflineMs).catch((err) =>
+      console.error('Module orchestration error', err)
+    );
+  }, intervalMs);
+}
+
+/**
+ * Stops the running module orchestrator.
+ */
+export function stopModuleOrchestrator() {
+  if (interval) {
+    clearInterval(interval);
+    interval = null;
+  }
+}

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkModules } from '../services/moduleOrchestrator';
+import Module from '../models/Module';
+
+const modules: any[] = [
+  {
+    _id: '1',
+    endpoints: { rest: 'https://m1.local/api' },
+    status: 'offline',
+  },
+  {
+    _id: '2',
+    endpoints: { rest: 'https://m2.local/api' },
+    status: 'offline',
+    lastHandshake: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
+  },
+];
+
+(Module as any).find = async () => modules;
+(Module as any).findByIdAndUpdate = async (id: any, update: any) => {
+  const mod = modules.find((m) => m._id === id);
+  Object.assign(mod, update);
+  return mod;
+};
+(Module as any).deleteOne = async ({ _id }: any) => {
+  const index = modules.findIndex((m) => m._id === _id);
+  if (index !== -1) modules.splice(index, 1);
+};
+
+(global as any).fetch = async (url: string) => {
+  if (String(url).includes('m1')) {
+    return { ok: true } as any;
+  }
+  return { ok: false } as any;
+};
+
+describe('moduleOrchestrator service', () => {
+  it('updates module status and prunes long-term offline modules', async () => {
+    await checkModules(30 * 24 * 60 * 60 * 1000);
+    assert.equal(modules.length, 1);
+    assert.equal(modules[0]._id, '1');
+    assert.equal(modules[0].status, 'online');
+    assert(modules[0].lastHandshake instanceof Date);
+  });
+});


### PR DESCRIPTION
## Summary
- add module orchestrator service that pings modules and prunes stale ones
- fix audit service imports to use relative paths
- add tests for module orchestrator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2b8832f083339c58f20610a50b66