### PR TITLE
Handle duplicate module registration

### DIFF
--- a/src/services/__tests__/moduleDiscovery.test.ts
+++ b/src/services/__tests__/moduleDiscovery.test.ts
@@ -1,14 +1,27 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import { registerModule, getModules } from '../moduleDiscovery';
 import Module from '../../models/Module';
 
 const store: any[] = [];
+
+beforeEach(() => {
+  store.length = 0;
+});
+
 (Module as any).create = async (doc: any) => {
-  store.push(doc);
-  return doc;
+  const moduleDoc = {
+    ...doc,
+    async save() {
+      return this;
+    },
+  };
+  store.push(moduleDoc);
+  return moduleDoc;
 };
 (Module as any).find = async () => store;
+(Module as any).findOne = async (query: any) =>
+  store.find((m) => m.name === query.name && m.ownerId === query.ownerId) || null;
 
 describe('moduleDiscovery service', () => {
   it('registers modules and lists them', async () => {
@@ -23,5 +36,28 @@ describe('moduleDiscovery service', () => {
     const modules = await getModules();
     assert.equal(modules.length, 1);
     assert.equal(modules[0].integrationToken, integrationToken);
+  });
+
+  it('updates manifest when module already exists for owner', async () => {
+    const first = await registerModule({
+      name: 'inventory',
+      version: '1.0.0',
+      ownerId: 'u1',
+      manifest: { a: 1 },
+      endpoints: { rest: 'https://inventory.local/api' },
+    });
+
+    const second = await registerModule({
+      name: 'inventory',
+      version: '1.0.1',
+      ownerId: 'u1',
+      manifest: { b: 2 },
+      endpoints: { rest: 'https://inventory.local/api/v2' },
+    });
+
+    assert.equal(store.length, 1);
+    assert.equal(second.integrationToken, first.integrationToken);
+    assert.deepEqual(second.module.manifest, { b: 2 });
+    assert.equal(second.module.version, '1.0.1');
   });
 });

--- a/src/services/moduleDiscovery.ts
+++ b/src/services/moduleDiscovery.ts
@@ -19,6 +19,20 @@ export interface RegisterModuleInput {
  * Returns the created module along with a generated integration token.
  */
 export async function registerModule(data: RegisterModuleInput) {
+  const existingModule = await Module.findOne({
+    name: data.name,
+    ownerId: data.ownerId,
+  });
+
+  if (existingModule) {
+    Object.assign(existingModule, data);
+    await existingModule.save();
+    return {
+      module: existingModule,
+      integrationToken: existingModule.integrationToken,
+    };
+  }
+
   const integrationToken = crypto.randomBytes(32).toString('hex');
   const savedModule = await Module.create({ ...data, integrationToken });
   return { module: savedModule, integrationToken };


### PR DESCRIPTION
## Summary
- avoid creating duplicate modules by owner/name; update existing manifest instead
- add unit tests covering manifest updates on duplicate registration

## Testing
- `npm run lint`
- `npm test`
- `npx tsc src/services/__tests__/moduleDiscovery.test.ts --outDir .tmp-svc-tests --module commonjs --target ES2019 --esModuleInterop --skipLibCheck --strictNullChecks && node --test .tmp-svc-tests/services/__tests__/moduleDiscovery.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a2f4bf5d08333bafc759a867732dc