### PR TITLE
Validate owner authentication for module registration

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -23,3 +23,9 @@ X-Module-Scopes: auth:login
 
 Si el módulo `64fae1...` incluye `auth:login` en su arreglo de `permissions`, la solicitud será procesada normalmente.
 De lo contrario, el middleware responderá con un mensaje de error e impedirá la ejecución del handler.
+
+## Autenticación de registro de módulos
+
+El endpoint `POST /api/modules/register` requiere un encabezado `Authorization` con un token JWT válido.
+El `ownerId` enviado en el cuerpo debe coincidir con el `userId` contenido en el token; de lo contrario la solicitud se rechaza
+con `401` (token inválido) o `403` (propietario distinto).

--- a/src/app/api/modules/register/route.ts
+++ b/src/app/api/modules/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import { registerModule } from '@/services/moduleDiscovery';
+import { verifyToken } from '@/auth';
 import { z } from 'zod';
 
 const registerSchema = z.object({
@@ -27,6 +28,23 @@ export async function POST(req: Request) {
   await dbConnect();
 
   try {
+    const authHeader = req.headers.get('authorization');
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return NextResponse.json(
+        { status: 'unauthorized', error: 'Missing or invalid token' },
+        { status: 401 }
+      );
+    }
+
+    const token = authHeader.split(' ')[1];
+    const payload = verifyToken(token) as { userId?: string } | null;
+    if (!payload || typeof payload.userId !== 'string') {
+      return NextResponse.json(
+        { status: 'unauthorized', error: 'Invalid token' },
+        { status: 401 }
+      );
+    }
+
     const body = await req.json();
     const parse = registerSchema.safeParse(body);
     if (!parse.success) {
@@ -37,6 +55,13 @@ export async function POST(req: Request) {
     }
 
     const data = parse.data;
+    if (payload.userId !== data.ownerId) {
+      return NextResponse.json(
+        { status: 'forbidden', error: 'Owner mismatch' },
+        { status: 403 }
+      );
+    }
+
     const compatibleVersion = isCompatible(data.version);
 
     if (!compatibleVersion) {
@@ -58,7 +83,7 @@ export async function POST(req: Request) {
         status = 'online';
         lastHandshake = new Date();
       }
-    } catch (err) {
+    } catch {
       // Module unreachable, keep status offline
     }
 


### PR DESCRIPTION
## Summary
- check Authorization token and ensure authenticated user matches `ownerId` when registering modules
- document module registration authentication requirements

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a322b13708333ae98b7eb821badf1