### PR TITLE
Use RabbitMQ in event bus

### DIFF
--- a/src/messaging/__tests__/eventBus.test.ts
+++ b/src/messaging/__tests__/eventBus.test.ts
@@ -1,13 +1,32 @@
 import { describe, it, TestContext } from 'node:test';
 import assert from 'node:assert/strict';
+import * as rabbitmq from '../../lib/rabbitmq';
 import { publish, subscribe } from '../eventBus';
 
 describe('eventBus', () => {
-  it('delivers published events to subscribers', async () => {
+  it('delivers published events to subscribers', async (t: TestContext) => {
+    const handlers = new Map<string, (payload: any) => Promise<void>>();
+    t.mock.method(rabbitmq, 'subscribe', async (
+      queue: string,
+      exchange: string,
+      routingKey: string,
+      onMessage: (payload: any) => Promise<void>,
+    ) => {
+      handlers.set(routingKey, onMessage);
+    });
+    t.mock.method(rabbitmq, 'publish', async (
+      exchange: string,
+      routingKey: string,
+      payload: any,
+    ) => {
+      const handler = handlers.get(routingKey);
+      if (handler) await handler(payload);
+    });
+
     const payload = { foo: 'bar' };
     let received: any;
 
-    subscribe('test.event', (data) => {
+    await subscribe('test.event', (data) => {
       received = data;
     });
 
@@ -16,10 +35,27 @@ describe('eventBus', () => {
   });
 
   it('resolves publish promise after async handlers', async (t: TestContext) => {
-    let handled = false;
+    const handlers = new Map<string, (payload: any) => Promise<void>>();
     t.mock.timers.enable();
+    t.mock.method(rabbitmq, 'subscribe', async (
+      queue: string,
+      exchange: string,
+      routingKey: string,
+      onMessage: (payload: any) => Promise<void>,
+    ) => {
+      handlers.set(routingKey, onMessage);
+    });
+    t.mock.method(rabbitmq, 'publish', async (
+      exchange: string,
+      routingKey: string,
+      payload: any,
+    ) => {
+      const handler = handlers.get(routingKey);
+      if (handler) await handler(payload);
+    });
 
-    subscribe('async.event', async () => {
+    let handled = false;
+    await subscribe('async.event', async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       handled = true;
     });

--- a/src/messaging/eventBus.ts
+++ b/src/messaging/eventBus.ts
@@ -1,25 +1,27 @@
-import Broker from "../lib/broker";
+import { randomUUID } from "crypto";
+import * as rabbitmq from "../lib/rabbitmq";
 
 export interface Event<T> {
   type: string;
   payload: T;
 }
 
-const broker = new Broker();
-
 /**
- * Publish an event using the underlying Broker instance.
+ * Publish an event to the default exchange.
  */
-export function publish<T>(type: string, payload: T): Promise<void> {
-  return broker.publish(type, payload);
+export async function publish<T>(type: string, payload: T): Promise<void> {
+  await rabbitmq.publish(rabbitmq.EXCHANGE_NAME, type, payload);
 }
 
 /**
- * Subscribe to a given event type.
+ * Subscribe to a given event type using a unique queue per subscriber.
  */
-export function subscribe<T>(
+export async function subscribe<T>(
   type: string,
   handler: (payload: T) => Promise<void> | void,
-): void {
-  broker.subscribe(type, handler);
+): Promise<void> {
+  const queue = `${type}.${randomUUID()}`;
+  await rabbitmq.subscribe(queue, rabbitmq.EXCHANGE_NAME, type, async (payload: T) => {
+    await handler(payload);
+  });
 }

--- a/src/modules/example/index.ts
+++ b/src/modules/example/index.ts
@@ -1,25 +1,11 @@
-import Broker from "../../lib/broker";
+import { publish, subscribe } from "../../messaging/eventBus";
 
-// Create a broker with one retry before moving messages to the dead‑letter queue.
-const broker = new Broker({ maxRetries: 1, retryDelayMs: 50 });
-
-// Basic publish/subscribe usage.
-broker.subscribe("greeting", async (payload: { text: string }) => {
+subscribe("greeting", async (payload: { text: string }) => {
   console.warn("received:", payload.text);
 });
 
-// Demonstrate retries and DLQ handling.
-broker.subscribe("task", async () => {
-  throw new Error("fail");
-});
-
-broker.onDeadLetter("task", (payload) => {
-  console.error("moved to DLQ:", payload);
-});
-
 async function main() {
-  await broker.publish("greeting", { text: "hello" });
-  await broker.publish("task", { id: 1 });
+  await publish("greeting", { text: "hello" });
 }
 
 main().catch(console.error);


### PR DESCRIPTION
## Summary
- replace in-memory broker in event bus with RabbitMQ-based publish and subscribe
- wire publish/subscribe to `EXCHANGE_NAME` constant
- update example module and event bus tests for new API

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a341ccda08333b74160e57116a037