### PR TITLE
Ping modules in parallel before pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file.
 - AGENTS guideline to record significant changes in `CHANGELOG.md`.
 - Module orchestrator service to monitor registered modules and prune stale entries.
 
+### Changed
+- Module orchestrator now pings modules in parallel before pruning.
+
 ## [0.5.2] - 2025-08-11
 
 ### Added

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -15,16 +15,21 @@ export async function checkModules(pruneOfflineMs?: number) {
   const modules = await Module.find();
   const now = Date.now();
 
-  for (const mod of modules) {
-    const pingUrl = new URL('/ping', mod.endpoints.rest).toString();
-    let online = false;
-    try {
-      const res = await fetch(pingUrl);
-      online = res.ok;
-    } catch {
-      online = false;
-    }
+  const results = await Promise.all(
+    modules.map(async (mod) => {
+      const pingUrl = new URL('/ping', mod.endpoints.rest).toString();
+      let online = false;
+      try {
+        const res = await fetch(pingUrl);
+        online = res.ok;
+      } catch {
+        online = false;
+      }
+      return { mod, online };
+    })
+  );
 
+  for (const { mod, online } of results) {
     if (online) {
       await Module.findByIdAndUpdate(mod._id, {
         status: 'online',


### PR DESCRIPTION
## Summary
- ping modules concurrently in module orchestrator before pruning
- log change in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a38c5355c8333849fbabb2b51a63d