### PR TITLE
Add timeout for module pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.
+- Module orchestrator pings now have a timeout using `AbortController` to mark modules offline on timeout.
 
 ## [0.5.2] - 2025-08-11
 

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -11,7 +11,10 @@ export interface OrchestratorOptions {
  * Pings registered modules and updates their status.
  * Optionally removes modules that have been offline for longer than `pruneOfflineMs`.
  */
-export async function checkModules(pruneOfflineMs?: number) {
+export async function checkModules(
+  pruneOfflineMs?: number,
+  pingTimeoutMs = 5_000
+) {
   const modules = await Module.find();
   const now = Date.now();
 
@@ -19,11 +22,19 @@ export async function checkModules(pruneOfflineMs?: number) {
     modules.map(async (mod) => {
       const pingUrl = new URL('/ping', mod.endpoints.rest).toString();
       let online = false;
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), pingTimeoutMs);
       try {
-        const res = await fetch(pingUrl);
+        const res = await fetch(pingUrl, { signal: controller.signal });
         online = res.ok;
-      } catch {
-        online = false;
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          online = false;
+        } else {
+          online = false;
+        }
+      } finally {
+        clearTimeout(timeout);
       }
       return { mod, online };
     })

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -15,6 +15,11 @@ const modules: any[] = [
     status: 'offline',
     lastHandshake: new Date(Date.now() - 40 * 24 * 60 * 60 * 1000),
   },
+  {
+    _id: '3',
+    endpoints: { rest: 'https://m3.local/api' },
+    status: 'offline',
+  },
 ];
 
 (Module as any).find = async () => modules;
@@ -28,19 +33,35 @@ const modules: any[] = [
   if (index !== -1) modules.splice(index, 1);
 };
 
-(global as any).fetch = async (url: string) => {
+(global as any).fetch = (url: string, { signal }: any = {}) => {
   if (String(url).includes('m1')) {
-    return { ok: true } as any;
+    return Promise.resolve({ ok: true } as any);
   }
-  return { ok: false } as any;
+  if (String(url).includes('m2')) {
+    return Promise.resolve({ ok: false } as any);
+  }
+  if (String(url).includes('m3')) {
+    return new Promise((_res, rej) => {
+      signal?.addEventListener('abort', () => {
+        const err = new Error('Aborted');
+        (err as any).name = 'AbortError';
+        rej(err);
+      });
+    });
+  }
+  return Promise.resolve({ ok: false } as any);
 };
 
 describe('moduleOrchestrator service', () => {
   it('updates module status and prunes long-term offline modules', async () => {
-    await checkModules(30 * 24 * 60 * 60 * 1000);
-    assert.equal(modules.length, 1);
-    assert.equal(modules[0]._id, '1');
-    assert.equal(modules[0].status, 'online');
-    assert(modules[0].lastHandshake instanceof Date);
+    await checkModules(30 * 24 * 60 * 60 * 1000, 50);
+    assert.equal(modules.length, 2);
+    const m1 = modules.find((m) => m._id === '1');
+    const m3 = modules.find((m) => m._id === '3');
+    assert(m1);
+    assert(m3);
+    assert.equal(m1.status, 'online');
+    assert(m1.lastHandshake instanceof Date);
+    assert.equal(m3.status, 'offline');
   });
 });


### PR DESCRIPTION
## Summary
- timeout module health checks using AbortController and mark offline on timeout
- cover ping timeouts in module orchestrator tests
- document ping timeout in CHANGELOG

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a39e52d388333a51f7ef386a0ca0e