### PR TITLE
Handle invalid ping URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator now pings modules in parallel before pruning.
 - Module orchestrator pings now have a timeout using `AbortController` to mark modules offline on timeout.
 
+### Fixed
+- Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.
+
 ## [0.5.2] - 2025-08-11
 
 ### Added

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -20,7 +20,14 @@ export async function checkModules(
 
   const results = await Promise.all(
     modules.map(async (mod) => {
-      const pingUrl = new URL('/ping', mod.endpoints.rest).toString();
+      let pingUrl: string;
+      try {
+        pingUrl = new URL('/ping', mod.endpoints.rest).toString();
+      } catch (err) {
+        console.error('Invalid ping URL for module', mod._id, err);
+        await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+        return null;
+      }
       let online = false;
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), pingTimeoutMs);
@@ -40,7 +47,9 @@ export async function checkModules(
     })
   );
 
-  for (const { mod, online } of results) {
+  for (const result of results) {
+    if (!result) continue;
+    const { mod, online } = result;
     if (online) {
       await Module.findByIdAndUpdate(mod._id, {
         status: 'online',

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -20,6 +20,11 @@ const modules: any[] = [
     endpoints: { rest: 'https://m3.local/api' },
     status: 'offline',
   },
+  {
+    _id: '4',
+    endpoints: { rest: 'invalid-url' },
+    status: 'online',
+  },
 ];
 
 (Module as any).find = async () => modules;
@@ -55,13 +60,16 @@ const modules: any[] = [
 describe('moduleOrchestrator service', () => {
   it('updates module status and prunes long-term offline modules', async () => {
     await checkModules(30 * 24 * 60 * 60 * 1000, 50);
-    assert.equal(modules.length, 2);
+    assert.equal(modules.length, 3);
     const m1 = modules.find((m) => m._id === '1');
     const m3 = modules.find((m) => m._id === '3');
+    const m4 = modules.find((m) => m._id === '4');
     assert(m1);
     assert(m3);
+    assert(m4);
     assert.equal(m1.status, 'online');
     assert(m1.lastHandshake instanceof Date);
     assert.equal(m3.status, 'offline');
+    assert.equal(m4.status, 'offline');
   });
 });


### PR DESCRIPTION
## Summary
- mark modules offline and skip fetch when their ping URL is invalid
- test orchestrator behavior with invalid module URLs
- document ping URL handling in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3b279f208333ae4985ac515c7f71