### PR TITLE
Serialize module orchestrator cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.
+- Module orchestrator runs sequentially, avoiding overlapping cycles and resetting its state on errors.
 
 ## [0.5.2] - 2025-08-11
 

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -1,6 +1,7 @@
 import Module from '../models/Module';
 
-let interval: NodeJS.Timeout | null = null;
+let timer: NodeJS.Timeout | null = null;
+let isRunning = false;
 
 export interface OrchestratorOptions {
   intervalMs?: number;
@@ -74,20 +75,32 @@ export async function checkModules(
  */
 export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
   const { intervalMs = 60_000, pruneOfflineMs } = options;
-  if (interval) return;
-  interval = setInterval(() => {
-    checkModules(pruneOfflineMs).catch((err) =>
-      console.error('Module orchestration error', err)
-    );
-  }, intervalMs);
+  if (timer) return;
+
+  const run = async () => {
+    if (isRunning) return;
+    isRunning = true;
+    try {
+      await checkModules(pruneOfflineMs);
+    } catch (err) {
+      console.error('Module orchestration error', err);
+    } finally {
+      isRunning = false;
+      if (timer) {
+        timer = setTimeout(run, intervalMs);
+      }
+    }
+  };
+
+  timer = setTimeout(run, intervalMs);
 }
 
 /**
  * Stops the running module orchestrator.
  */
 export function stopModuleOrchestrator() {
-  if (interval) {
-    clearInterval(interval);
-    interval = null;
+  if (timer) {
+    clearTimeout(timer);
+    timer = null;
   }
 }

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Module from '../models/Module';
+import { startModuleOrchestrator, stopModuleOrchestrator } from '../services/moduleOrchestrator';
+
+const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+beforeEach(async () => {
+  stopModuleOrchestrator();
+  await wait(50);
+});
+
+describe('module orchestrator cycle control', () => {
+  it('runs without overlapping cycles', async () => {
+    let running = 0;
+    let maxRunning = 0;
+    let calls = 0;
+    (Module as any).find = async () => {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+      await wait(80);
+      running--;
+      calls++;
+      return [];
+    };
+
+    startModuleOrchestrator({ intervalMs: 10 });
+    await wait(200);
+    stopModuleOrchestrator();
+    await wait(100);
+
+    assert.equal(maxRunning, 1);
+    assert.ok(calls >= 2);
+  });
+
+  it('recovers and schedules new cycle after errors', async () => {
+    let calls = 0;
+    (Module as any).find = async () => {
+      calls++;
+      if (calls === 1) throw new Error('fail');
+      return [];
+    };
+
+    startModuleOrchestrator({ intervalMs: 10 });
+    await wait(120);
+    stopModuleOrchestrator();
+    await wait(50);
+
+    assert.ok(calls >= 2);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure module orchestrator waits for each check to finish before scheduling the next
- reset orchestrator state and flag even when errors occur
- test orchestrator cycle to prevent overlap and verify recovery after errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a3cee3c708333824dcfb1d40048c1