### PR TITLE
Emit module status events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - AGENTS guideline to record significant changes in `CHANGELOG.md`.
 - Module orchestrator service to monitor registered modules and prune stale entries.
+- Module orchestrator now emits `module.online`, `module.offline`, and `module.removed` events with corresponding logs.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/messaging.md
+++ b/docs/messaging.md
@@ -13,3 +13,13 @@ A **command** conveys an explicit request for an action. Unlike events, commands
 ## Saga
 
 A **saga** coordinates a long‑running transaction across multiple services using a series of local transactions and compensating actions. Each step publishes events or commands that trigger the next step. If a step fails, compensating commands roll back previous actions to maintain consistency.
+
+## Module status events
+
+The module orchestrator emits events to notify other services when module availability changes:
+
+- `module.online` – published after a successful ping.
+- `module.offline` – published when a module becomes unreachable.
+- `module.removed` – published when a module is pruned for being offline too long.
+
+Each event payload contains the `moduleId` of the affected module.

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -1,4 +1,5 @@
 import Module from '../models/Module';
+import * as eventBus from '../messaging/eventBus';
 
 let timer: NodeJS.Timeout | null = null;
 let isRunning = false;
@@ -56,6 +57,12 @@ export async function checkModules(
         status: 'online',
         lastHandshake: new Date(),
       });
+      console.info(`Module ${mod._id} is online`);
+      try {
+        await eventBus.publish('module.online', { moduleId: String(mod._id) });
+      } catch (err) {
+        console.error('Failed to publish module.online event', err);
+      }
     } else {
       if (
         pruneOfflineMs &&
@@ -63,9 +70,21 @@ export async function checkModules(
         now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
       ) {
         await Module.deleteOne({ _id: mod._id });
+        console.info(`Module ${mod._id} removed after exceeding offline threshold`);
+        try {
+          await eventBus.publish('module.removed', { moduleId: String(mod._id) });
+        } catch (err) {
+          console.error('Failed to publish module.removed event', err);
+        }
         continue;
       }
       await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+      console.info(`Module ${mod._id} is offline`);
+      try {
+        await eventBus.publish('module.offline', { moduleId: String(mod._id) });
+      } catch (err) {
+        console.error('Failed to publish module.offline event', err);
+      }
     }
   }
 }

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -2,6 +2,9 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { checkModules } from '../services/moduleOrchestrator';
 import Module from '../models/Module';
+import * as eventBus from '../messaging/eventBus';
+
+(eventBus as any).publish = async () => {};
 
 const modules: any[] = [
   {

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -2,6 +2,9 @@ import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import Module from '../models/Module';
 import { startModuleOrchestrator, stopModuleOrchestrator } from '../services/moduleOrchestrator';
+import * as eventBus from '../messaging/eventBus';
+
+(eventBus as any).publish = async () => {};
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
 


### PR DESCRIPTION
## Summary
- publish `module.online`, `module.offline`, and `module.removed` events when modules change state
- document module status events in messaging guidelines
- log state transitions and record in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4532a7c08333b18be5db722c9094