### PR TITLE
Run orchestrator immediately on start

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -110,7 +110,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
       }
     }
   };
-
+  run();
   timer = setTimeout(run, intervalMs);
 }
 

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -28,12 +28,14 @@ describe('module orchestrator cycle control', () => {
     };
 
     startModuleOrchestrator({ intervalMs: 10 });
-    await wait(200);
+    await wait(5);
+    assert.equal(running, 1);
+    await wait(195);
     stopModuleOrchestrator();
     await wait(100);
 
     assert.equal(maxRunning, 1);
-    assert.ok(calls >= 2);
+    assert.ok(calls >= 3);
   });
 
   it('recovers and schedules new cycle after errors', async () => {
@@ -45,6 +47,8 @@ describe('module orchestrator cycle control', () => {
     };
 
     startModuleOrchestrator({ intervalMs: 10 });
+    await wait(1);
+    assert.equal(calls, 1);
     await wait(120);
     stopModuleOrchestrator();
     await wait(50);


### PR DESCRIPTION
## Summary
- invoke module orchestrator cycle right away before scheduling the next run
- assert orchestrator starts its first cycle immediately and adjust expectations in cycle tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a572ce3648333a42fb83021170723