### PR TITLE
Add logger utility and apply to module orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ All notable changes to this project will be documented in this file.
 - AGENTS guideline to record significant changes in `CHANGELOG.md`.
 - Module orchestrator service to monitor registered modules and prune stale entries.
 - Module orchestrator now emits `module.online`, `module.offline`, and `module.removed` events with corresponding logs.
+- Centralized logging utility.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.
 - Module orchestrator pings now have a timeout using `AbortController` to mark modules offline on timeout.
+- Module orchestrator uses the logging utility instead of `console`.
 
 ### Fixed
 - Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.

--- a/src/lib/__tests__/logger.test.ts
+++ b/src/lib/__tests__/logger.test.ts
@@ -1,0 +1,12 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import logger from '../logger';
+
+describe('logger', () => {
+  it('exposes standard logging methods', () => {
+    assert.equal(typeof logger.info, 'function');
+    assert.equal(typeof logger.warn, 'function');
+    assert.equal(typeof logger.error, 'function');
+    assert.equal(typeof logger.debug, 'function');
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,21 @@
+export type LogMethod = (...args: unknown[]) => void;
+
+interface Logger {
+  info: LogMethod;
+  warn: LogMethod;
+  error: LogMethod;
+  debug: LogMethod;
+}
+
+const logger: Logger = {
+  info: (...args) => console.info(...args),
+  warn: (...args) => console.warn(...args),
+  error: (...args) => console.error(...args),
+  debug: (...args) => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.debug(...args);
+    }
+  },
+};
+
+export default logger;

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -1,5 +1,6 @@
 import Module from '../models/Module';
 import * as eventBus from '../messaging/eventBus';
+import logger from '../lib/logger';
 
 let timer: NodeJS.Timeout | null = null;
 let isRunning = false;
@@ -26,7 +27,7 @@ export async function checkModules(
       try {
         pingUrl = new URL('/ping', mod.endpoints.rest).toString();
       } catch (err) {
-        console.error('Invalid ping URL for module', mod._id, err);
+        logger.error('Invalid ping URL for module', mod._id, err);
         await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
         return null;
       }
@@ -57,11 +58,11 @@ export async function checkModules(
         status: 'online',
         lastHandshake: new Date(),
       });
-      console.info(`Module ${mod._id} is online`);
+      logger.info(`Module ${mod._id} is online`);
       try {
         await eventBus.publish('module.online', { moduleId: String(mod._id) });
       } catch (err) {
-        console.error('Failed to publish module.online event', err);
+        logger.error('Failed to publish module.online event', err);
       }
     } else {
       if (
@@ -70,20 +71,20 @@ export async function checkModules(
         now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
       ) {
         await Module.deleteOne({ _id: mod._id });
-        console.info(`Module ${mod._id} removed after exceeding offline threshold`);
+        logger.info(`Module ${mod._id} removed after exceeding offline threshold`);
         try {
           await eventBus.publish('module.removed', { moduleId: String(mod._id) });
         } catch (err) {
-          console.error('Failed to publish module.removed event', err);
+          logger.error('Failed to publish module.removed event', err);
         }
         continue;
       }
       await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
-      console.info(`Module ${mod._id} is offline`);
+      logger.info(`Module ${mod._id} is offline`);
       try {
         await eventBus.publish('module.offline', { moduleId: String(mod._id) });
       } catch (err) {
-        console.error('Failed to publish module.offline event', err);
+        logger.error('Failed to publish module.offline event', err);
       }
     }
   }
@@ -102,7 +103,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     try {
       await checkModules(pruneOfflineMs);
     } catch (err) {
-      console.error('Module orchestration error', err);
+      logger.error('Module orchestration error', err);
     } finally {
       isRunning = false;
       if (timer) {


### PR DESCRIPTION
## Summary
- add reusable logger utility
- route module orchestrator logs through logger
- document logging utility in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a603f3cd88333bb54a97c093f31ce