### PR TITLE
Handle DB errors in module orchestrator loop

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { checkModules } from '../moduleOrchestrator';
+import Module from '../../models/Module';
+import * as eventBus from '../../messaging/eventBus';
+
+let originalFetch: typeof fetch;
+
+beforeEach(() => {
+  originalFetch = global.fetch;
+  (eventBus as any).publish = async () => {};
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('moduleOrchestrator service', () => {
+  it('continues when findByIdAndUpdate fails', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+      { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = async () => modules;
+    const updated: string[] = [];
+    (Module as any).findByIdAndUpdate = async (id: string) => {
+      updated.push(String(id));
+      if (String(id) === '1') throw new Error('fail');
+    };
+    global.fetch = async () => ({ ok: true }) as any;
+
+    await checkModules();
+
+    assert.deepEqual(updated, ['1', '2']);
+  });
+
+  it('continues when deleteOne fails', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date(0) },
+      { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = async () => modules;
+    const updated: string[] = [];
+    (Module as any).findByIdAndUpdate = async (id: string) => {
+      updated.push(String(id));
+    };
+    const deleted: string[] = [];
+    (Module as any).deleteOne = async (query: any) => {
+      deleted.push(String(query._id));
+      throw new Error('delete fail');
+    };
+    global.fetch = async (url: string) =>
+      ({ ok: !url.includes('m1') }) as any;
+
+    await checkModules(1);
+
+    assert.deepEqual(deleted, ['1']);
+    assert.deepEqual(updated, ['2']);
+  });
+});

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -59,10 +59,15 @@ export async function checkModules(
     if (!result) continue;
     const { mod, online } = result;
     if (online) {
-      await Module.findByIdAndUpdate(mod._id, {
-        status: 'online',
-        lastHandshake: new Date(),
-      });
+      try {
+        await Module.findByIdAndUpdate(mod._id, {
+          status: 'online',
+          lastHandshake: new Date(),
+        });
+      } catch (err) {
+        logger.error('Failed to update module to online', mod._id, err);
+        continue;
+      }
       logger.info(`Module ${mod._id} is online`);
       try {
         await eventBus.publish('module.online', { moduleId: String(mod._id) });
@@ -75,7 +80,12 @@ export async function checkModules(
         mod.lastHandshake &&
         now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
       ) {
-        await Module.deleteOne({ _id: mod._id });
+        try {
+          await Module.deleteOne({ _id: mod._id });
+        } catch (err) {
+          logger.error('Failed to delete module', mod._id, err);
+          continue;
+        }
         logger.info(`Module ${mod._id} removed after exceeding offline threshold`);
         try {
           await eventBus.publish('module.removed', { moduleId: String(mod._id) });
@@ -84,7 +94,12 @@ export async function checkModules(
         }
         continue;
       }
-      await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+      try {
+        await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+      } catch (err) {
+        logger.error('Failed to update module to offline', mod._id, err);
+        continue;
+      }
       logger.info(`Module ${mod._id} is offline`);
       try {
         await eventBus.publish('module.offline', { moduleId: String(mod._id) });


### PR DESCRIPTION
## Summary
- wrap database updates and deletions in the module orchestrator with try/catch to log errors and continue processing
- add tests ensuring the orchestrator continues after findByIdAndUpdate or deleteOne failures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a659657f48333a135583a4da35364