### PR TITLE
Refactor orchestrator scheduling

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -4,6 +4,7 @@ import logger from '../lib/logger';
 
 let timer: NodeJS.Timeout | null = null;
 let isRunning = false;
+let isActive = false;
 
 export interface OrchestratorOptions {
   intervalMs?: number;
@@ -130,10 +131,11 @@ export async function checkModules(
  */
 export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
   const { intervalMs = 60_000, pruneOfflineMs, maxConcurrentPings } = options;
-  if (timer) return;
+  if (isActive) return;
+  isActive = true;
 
   const run = async () => {
-    if (isRunning) return;
+    if (!isActive || isRunning) return;
     isRunning = true;
     try {
       await checkModules(pruneOfflineMs, undefined, maxConcurrentPings);
@@ -141,19 +143,21 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
       logger.error('Module orchestration error', err);
     } finally {
       isRunning = false;
-      if (timer) {
+      if (isActive) {
+        if (timer) clearTimeout(timer);
         timer = setTimeout(run, intervalMs);
       }
     }
   };
+
   run();
-  timer = setTimeout(run, intervalMs);
 }
 
 /**
  * Stops the running module orchestrator.
  */
 export function stopModuleOrchestrator() {
+  isActive = false;
   if (timer) {
     clearTimeout(timer);
     timer = null;

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -55,4 +55,20 @@ describe('module orchestrator cycle control', () => {
 
     assert.ok(calls >= 2);
   });
+
+  it('stops scheduling when stopped mid-cycle', async () => {
+    let calls = 0;
+    (Module as any).find = async () => {
+      calls++;
+      await wait(50);
+      return [];
+    };
+
+    startModuleOrchestrator({ intervalMs: 10 });
+    await wait(5);
+    stopModuleOrchestrator();
+    await wait(100);
+
+    assert.equal(calls, 1);
+  });
 });


### PR DESCRIPTION
## Summary
- centralize module orchestrator rescheduling to a single timer
- add test coverage for stopping the orchestrator mid-cycle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a69d5f4048333a835ff6111caa240