### PR TITLE
feat: add ping timeout option

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { checkModules } from '../moduleOrchestrator';
+import {
+  checkModules,
+  startModuleOrchestrator,
+  stopModuleOrchestrator,
+} from '../moduleOrchestrator';
 import Module from '../../models/Module';
 import * as eventBus from '../../messaging/eventBus';
 
@@ -133,5 +137,51 @@ describe('moduleOrchestrator service', () => {
     await checkModules(undefined, undefined, 5);
 
     assert.ok(maxActive <= 5);
+  });
+
+  it('aborts ping after pingTimeoutMs', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = async () => modules;
+    (Module as any).findByIdAndUpdate = async () => {};
+    const durations: number[] = [];
+    global.fetch = async (_: string, init: any) =>
+      new Promise((resolve) => {
+        const start = Date.now();
+        init.signal.addEventListener('abort', () => {
+          durations.push(Date.now() - start);
+          resolve({ ok: false } as any);
+        });
+      });
+
+    await checkModules(undefined, 10);
+
+    assert.ok(durations[0] >= 10);
+    assert.ok(durations[0] < 50);
+  });
+
+  it('passes pingTimeoutMs from startModuleOrchestrator to checkModules', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = async () => modules;
+    (Module as any).findByIdAndUpdate = async () => {};
+    const durations: number[] = [];
+    global.fetch = async (_: string, init: any) =>
+      new Promise((resolve) => {
+        const start = Date.now();
+        init.signal.addEventListener('abort', () => {
+          durations.push(Date.now() - start);
+          resolve({ ok: false } as any);
+        });
+      });
+
+    startModuleOrchestrator({ intervalMs: 1_000, pingTimeoutMs: 10 });
+    await new Promise((r) => setTimeout(r, 50));
+    stopModuleOrchestrator();
+
+    assert.ok(durations[0] >= 10);
+    assert.ok(durations[0] < 50);
   });
 });

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -10,6 +10,7 @@ export interface OrchestratorOptions {
   intervalMs?: number;
   pruneOfflineMs?: number;
   maxConcurrentPings?: number;
+  pingTimeoutMs?: number;
 }
 
 /**
@@ -130,7 +131,12 @@ export async function checkModules(
  * Starts periodic module orchestration.
  */
 export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
-  const { intervalMs = 60_000, pruneOfflineMs, maxConcurrentPings } = options;
+  const {
+    intervalMs = 60_000,
+    pruneOfflineMs,
+    maxConcurrentPings,
+    pingTimeoutMs,
+  } = options;
   if (isActive) return;
   isActive = true;
 
@@ -138,7 +144,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     if (!isActive || isRunning) return;
     isRunning = true;
     try {
-      await checkModules(pruneOfflineMs, undefined, maxConcurrentPings);
+      await checkModules(pruneOfflineMs, pingTimeoutMs, maxConcurrentPings);
     } catch (err) {
       logger.error('Module orchestration error', err);
     } finally {


### PR DESCRIPTION
## Summary
- allow configuring ping timeout for module orchestration
- cover ping timeout option with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6fa155d883339cc27832f0483dee