### PR TITLE
Paginate module orchestrator checks

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -25,7 +25,11 @@ describe('moduleOrchestrator service', () => {
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     const updated: string[] = [];
     (Module as any).findByIdAndUpdate = async (id: string) => {
       updated.push(String(id));
@@ -43,7 +47,11 @@ describe('moduleOrchestrator service', () => {
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date(0) },
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     const updated: string[] = [];
     (Module as any).findByIdAndUpdate = async (id: string) => {
       updated.push(String(id));
@@ -71,7 +79,11 @@ describe('moduleOrchestrator service', () => {
         status: 'offline',
       },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     const updated: Array<{ id: string; status: string }> = [];
     (Module as any).findByIdAndUpdate = async (id: string, update: any) => {
       updated.push({ id: String(id), status: update.status });
@@ -96,7 +108,11 @@ describe('moduleOrchestrator service', () => {
         lastHandshake: new Date(0),
       },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     (Module as any).findByIdAndUpdate = async () => {
       throw new Error('should not update');
     };
@@ -122,7 +138,11 @@ describe('moduleOrchestrator service', () => {
       endpoints: { rest: `http://m${i}` },
       lastHandshake: new Date(),
     }));
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     (Module as any).findByIdAndUpdate = async () => {};
     let active = 0;
     let maxActive = 0;
@@ -139,11 +159,42 @@ describe('moduleOrchestrator service', () => {
     assert.ok(maxActive <= 5);
   });
 
+  it('iterates over multiple batches', async () => {
+    const modules = Array.from({ length: 120 }, (_, i) => ({
+      _id: String(i),
+      endpoints: { rest: `http://m${i}` },
+      lastHandshake: new Date(),
+    }));
+    let findCalls = 0;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => {
+          findCalls++;
+          return Promise.resolve(modules.slice(s, s + l));
+        },
+      }),
+    });
+    const updated: string[] = [];
+    (Module as any).findByIdAndUpdate = async (id: string) => {
+      updated.push(String(id));
+    };
+    global.fetch = async () => ({ ok: true }) as any;
+
+    await checkModules();
+
+    assert.equal(findCalls, 3);
+    assert.equal(updated.length, modules.length);
+  });
+
   it('aborts ping after pingTimeoutMs', async () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     (Module as any).findByIdAndUpdate = async () => {};
     const durations: number[] = [];
     global.fetch = async (_: string, init: any) =>
@@ -165,7 +216,11 @@ describe('moduleOrchestrator service', () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = async () => modules;
+    (Module as any).find = () => ({
+      skip: (s: number) => ({
+        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      }),
+    });
     (Module as any).findByIdAndUpdate = async () => {};
     const durations: number[] = [];
     global.fetch = async (_: string, init: any) =>

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -22,8 +22,8 @@ export async function checkModules(
   pingTimeoutMs = 5_000,
   maxConcurrentPings = 10
 ) {
-  const modules = await Module.find({ deletedAt: { $exists: false } });
   const now = Date.now();
+  const batchSize = 100;
 
   async function pingModule(mod: any) {
     let pingUrl: string;
@@ -57,73 +57,91 @@ export async function checkModules(
     return { mod, online };
   }
 
-  const results: Array<{ mod: any; online: boolean } | null> = [];
-  let index = 0;
-  async function worker() {
-    while (true) {
-      const mod = modules[index++];
-      if (!mod) break;
-      results.push(await pingModule(mod));
+  async function processBatch(modules: any[]) {
+    const results: Array<{ mod: any; online: boolean } | null> = [];
+    let index = 0;
+    async function worker() {
+      while (true) {
+        const mod = modules[index++];
+        if (!mod) break;
+        results.push(await pingModule(mod));
+      }
     }
-  }
-  const workers = Array.from(
-    { length: Math.min(maxConcurrentPings, modules.length) },
-    () => worker()
-  );
-  await Promise.all(workers);
+    const workers = Array.from(
+      { length: Math.min(maxConcurrentPings, modules.length) },
+      () => worker()
+    );
+    await Promise.all(workers);
 
-  for (const result of results) {
-    if (!result) continue;
-    const { mod, online } = result;
-    if (online) {
-      try {
-        await Module.findByIdAndUpdate(mod._id, {
-          status: 'online',
-          lastHandshake: new Date(),
-        });
-      } catch (err) {
-        logger.error('Failed to update module to online', mod._id, err);
-        continue;
-      }
-      logger.info(`Module ${mod._id} is online`);
-      try {
-        await eventBus.publish('module.online', { moduleId: String(mod._id) });
-      } catch (err) {
-        logger.error('Failed to publish module.online event', err);
-      }
-    } else {
-      if (
-        pruneOfflineMs &&
-        mod.lastHandshake &&
-        now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
-      ) {
+    for (const result of results) {
+      if (!result) continue;
+      const { mod, online } = result;
+      if (online) {
         try {
-          await Module.deleteOne({ _id: mod._id });
+          await Module.findByIdAndUpdate(mod._id, {
+            status: 'online',
+            lastHandshake: new Date(),
+          });
         } catch (err) {
-          logger.error('Failed to delete module', mod._id, err);
+          logger.error('Failed to update module to online', mod._id, err);
           continue;
         }
-        logger.info(`Module ${mod._id} removed after exceeding offline threshold`);
+        logger.info(`Module ${mod._id} is online`);
         try {
-          await eventBus.publish('module.removed', { moduleId: String(mod._id) });
+          await eventBus.publish('module.online', { moduleId: String(mod._id) });
         } catch (err) {
-          logger.error('Failed to publish module.removed event', err);
+          logger.error('Failed to publish module.online event', err);
         }
-        continue;
-      }
-      try {
-        await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
-      } catch (err) {
-        logger.error('Failed to update module to offline', mod._id, err);
-        continue;
-      }
-      logger.info(`Module ${mod._id} is offline`);
-      try {
-        await eventBus.publish('module.offline', { moduleId: String(mod._id) });
-      } catch (err) {
-        logger.error('Failed to publish module.offline event', err);
+      } else {
+        if (
+          pruneOfflineMs &&
+          mod.lastHandshake &&
+          now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
+        ) {
+          try {
+            await Module.deleteOne({ _id: mod._id });
+          } catch (err) {
+            logger.error('Failed to delete module', mod._id, err);
+            continue;
+          }
+          logger.info(
+            `Module ${mod._id} removed after exceeding offline threshold`
+          );
+          try {
+            await eventBus.publish('module.removed', {
+              moduleId: String(mod._id),
+            });
+          } catch (err) {
+            logger.error('Failed to publish module.removed event', err);
+          }
+          continue;
+        }
+        try {
+          await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+        } catch (err) {
+          logger.error('Failed to update module to offline', mod._id, err);
+          continue;
+        }
+        logger.info(`Module ${mod._id} is offline`);
+        try {
+          await eventBus.publish('module.offline', {
+            moduleId: String(mod._id),
+          });
+        } catch (err) {
+          logger.error('Failed to publish module.offline event', err);
+        }
       }
     }
+  }
+
+  let skip = 0;
+  while (true) {
+    const modules = await Module.find({ deletedAt: { $exists: false } })
+      .skip(skip)
+      .limit(batchSize);
+    if (modules.length === 0) break;
+    await processBatch(modules);
+    skip += modules.length;
   }
 }
 

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -14,10 +14,18 @@ const emitted: Array<{ event: string; moduleId: string }> = [];
 
 let modules: any[] = [];
 
-(Module as any).find = async (filter: any = {}) =>
-  modules.filter((m) =>
-    filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true
-  );
+(Module as any).find = (filter: any = {}) => ({
+  skip: (s: number) => ({
+    limit: (l: number) =>
+      Promise.resolve(
+        modules
+          .filter((m) =>
+            filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true
+          )
+          .slice(s, s + l)
+      ),
+  }),
+});
 (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
   const mod = modules.find((m) => m._id === id);
   Object.assign(mod, update);

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -18,14 +18,18 @@ describe('module orchestrator cycle control', () => {
     let running = 0;
     let maxRunning = 0;
     let calls = 0;
-    (Module as any).find = async () => {
-      running++;
-      maxRunning = Math.max(maxRunning, running);
-      await wait(80);
-      running--;
-      calls++;
-      return [];
-    };
+    (Module as any).find = () => ({
+      skip: (_s: number) => ({
+        limit: async (_l: number) => {
+          running++;
+          maxRunning = Math.max(maxRunning, running);
+          await wait(80);
+          running--;
+          calls++;
+          return [];
+        },
+      }),
+    });
 
     startModuleOrchestrator({ intervalMs: 10 });
     await wait(5);
@@ -40,11 +44,15 @@ describe('module orchestrator cycle control', () => {
 
   it('recovers and schedules new cycle after errors', async () => {
     let calls = 0;
-    (Module as any).find = async () => {
-      calls++;
-      if (calls === 1) throw new Error('fail');
-      return [];
-    };
+    (Module as any).find = () => ({
+      skip: (_s: number) => ({
+        limit: async (_l: number) => {
+          calls++;
+          if (calls === 1) throw new Error('fail');
+          return [];
+        },
+      }),
+    });
 
     startModuleOrchestrator({ intervalMs: 10 });
     await wait(1);
@@ -58,11 +66,15 @@ describe('module orchestrator cycle control', () => {
 
   it('stops scheduling when stopped mid-cycle', async () => {
     let calls = 0;
-    (Module as any).find = async () => {
-      calls++;
-      await wait(50);
-      return [];
-    };
+    (Module as any).find = () => ({
+      skip: (_s: number) => ({
+        limit: async (_l: number) => {
+          calls++;
+          await wait(50);
+          return [];
+        },
+      }),
+    });
 
     startModuleOrchestrator({ intervalMs: 10 });
     await wait(5);


### PR DESCRIPTION
## Summary
- process modules in paginated batches to avoid large queries
- test orchestrator iteration across multiple batches

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a70c1ce288333b81fad53259de8d7