### PR TITLE
Add concurrency limit test for module orchestrator

### DIFF
--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -137,4 +137,27 @@ describe('moduleOrchestrator service', () => {
     assert.equal(m2.lastHandshake, undefined);
     assert.deepEqual(emitted, [{ event: 'module.online', moduleId: '1' }]);
   });
+
+  it('limits parallel pings to maxConcurrentPings', async () => {
+    modules = Array.from({ length: 20 }, (_, i) => ({
+      _id: String(i + 1),
+      endpoints: { rest: `https://m${i + 1}.local/api` },
+      status: 'offline',
+    }));
+    const originalFetch = global.fetch;
+    let active = 0;
+    let maxActive = 0;
+    (global as any).fetch = async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((r) => setTimeout(r, 10));
+      active--;
+      return { ok: true } as any;
+    };
+
+    await checkModules(undefined, undefined, 5);
+
+    assert.ok(maxActive <= 5);
+    global.fetch = originalFetch;
+  });
 });


### PR DESCRIPTION
## Summary
- verify module orchestrator limits concurrent pings to `maxConcurrentPings`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a728b16408333a56b2ee81391db0e