### PR TITLE
Avoid duplicate module status events

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -77,6 +77,7 @@ export async function checkModules(
       if (!result) continue;
       const { mod, online } = result;
       if (online) {
+        const wasOnline = mod.status === 'online';
         try {
           await Module.findByIdAndUpdate(mod._id, {
             status: 'online',
@@ -87,10 +88,12 @@ export async function checkModules(
           continue;
         }
         logger.info(`Module ${mod._id} is online`);
-        try {
-          await eventBus.publish('module.online', { moduleId: String(mod._id) });
-        } catch (err) {
-          logger.error('Failed to publish module.online event', err);
+        if (!wasOnline) {
+          try {
+            await eventBus.publish('module.online', { moduleId: String(mod._id) });
+          } catch (err) {
+            logger.error('Failed to publish module.online event', err);
+          }
         }
       } else {
         if (
@@ -112,10 +115,11 @@ export async function checkModules(
               moduleId: String(mod._id),
             });
           } catch (err) {
-            logger.error('Failed to publish module.removed event', err);
-          }
-          continue;
+          logger.error('Failed to publish module.removed event', err);
         }
+        continue;
+      }
+        const wasOffline = mod.status === 'offline';
         try {
           await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
         } catch (err) {
@@ -123,12 +127,14 @@ export async function checkModules(
           continue;
         }
         logger.info(`Module ${mod._id} is offline`);
-        try {
-          await eventBus.publish('module.offline', {
-            moduleId: String(mod._id),
-          });
-        } catch (err) {
-          logger.error('Failed to publish module.offline event', err);
+        if (!wasOffline) {
+          try {
+            await eventBus.publish('module.offline', {
+              moduleId: String(mod._id),
+            });
+          } catch (err) {
+            logger.error('Failed to publish module.offline event', err);
+          }
         }
       }
     }

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -90,7 +90,6 @@ describe('moduleOrchestrator service', () => {
     assert.deepEqual(emitted, [
       { event: 'module.online', moduleId: '1' },
       { event: 'module.removed', moduleId: '2' },
-      { event: 'module.offline', moduleId: '3' },
     ]);
   });
 

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -1,16 +1,27 @@
 import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import Module from '../models/Module';
-import { startModuleOrchestrator, stopModuleOrchestrator } from '../services/moduleOrchestrator';
+import {
+  checkModules,
+  startModuleOrchestrator,
+  stopModuleOrchestrator,
+} from '../services/moduleOrchestrator';
 import * as eventBus from '../messaging/eventBus';
 
-(eventBus as any).publish = async () => {};
+const emitted: Array<{ event: string; moduleId: string }> = [];
+(eventBus as any).publish = async (
+  event: string,
+  payload: { moduleId: string }
+) => {
+  emitted.push({ event, moduleId: payload.moduleId });
+};
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 beforeEach(async () => {
   stopModuleOrchestrator();
   await wait(50);
+  emitted.length = 0;
 });
 
 describe('module orchestrator cycle control', () => {
@@ -82,5 +93,79 @@ describe('module orchestrator cycle control', () => {
     await wait(100);
 
     assert.equal(calls, 1);
+  });
+
+  it('emits module.online only when status changes', async () => {
+    const originalFind = Module.find;
+    const originalFindByIdAndUpdate = (Module as any).findByIdAndUpdate;
+    const originalFetch = global.fetch;
+    try {
+      const modules = [
+        {
+          _id: '1',
+          endpoints: { rest: 'https://m1.local/api' },
+          status: 'offline',
+        },
+      ];
+      (Module as any).find = () => ({
+        skip: (s: number) => ({
+          limit: async (_l: number) => modules.slice(s, s + _l),
+        }),
+      });
+      (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
+        const mod = modules.find((m) => m._id === id);
+        Object.assign(mod!, update);
+        return mod;
+      };
+      (global as any).fetch = async () => ({ ok: true } as any);
+
+      await checkModules(undefined, 50);
+      assert.deepEqual(emitted, [{ event: 'module.online', moduleId: '1' }]);
+
+      emitted.length = 0;
+      await checkModules(undefined, 50);
+      assert.deepEqual(emitted, []);
+    } finally {
+      (Module as any).find = originalFind;
+      (Module as any).findByIdAndUpdate = originalFindByIdAndUpdate;
+      global.fetch = originalFetch;
+    }
+  });
+
+  it('emits module.offline only when status changes', async () => {
+    const originalFind = Module.find;
+    const originalFindByIdAndUpdate = (Module as any).findByIdAndUpdate;
+    const originalFetch = global.fetch;
+    try {
+      const modules = [
+        {
+          _id: '1',
+          endpoints: { rest: 'https://m1.local/api' },
+          status: 'online',
+        },
+      ];
+      (Module as any).find = () => ({
+        skip: (s: number) => ({
+          limit: async (_l: number) => modules.slice(s, s + _l),
+        }),
+      });
+      (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
+        const mod = modules.find((m) => m._id === id);
+        Object.assign(mod!, update);
+        return mod;
+      };
+      (global as any).fetch = async () => ({ ok: false } as any);
+
+      await checkModules(undefined, 50);
+      assert.deepEqual(emitted, [{ event: 'module.offline', moduleId: '1' }]);
+
+      emitted.length = 0;
+      await checkModules(undefined, 50);
+      assert.deepEqual(emitted, []);
+    } finally {
+      (Module as any).find = originalFind;
+      (Module as any).findByIdAndUpdate = originalFindByIdAndUpdate;
+      global.fetch = originalFetch;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- skip publishing module.online/offline if status unchanged
- add regression tests for single-event emission on state transitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a756412508333945aed8a753159c0