### PR TITLE
Ensure stable ordering in module orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.
 - Module orchestrator publishes `module.offline` when ping URL is invalid.
 - Module orchestrator runs sequentially, avoiding overlapping cycles and resetting its state on errors.
+- Module orchestrator sorts modules by `_id` before pagination to ensure stable ordering.
 
 ## [0.5.2] - 2025-08-11
 

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -26,8 +26,10 @@ describe('moduleOrchestrator service', () => {
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     const updated: string[] = [];
@@ -48,8 +50,10 @@ describe('moduleOrchestrator service', () => {
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     const updated: string[] = [];
@@ -80,8 +84,10 @@ describe('moduleOrchestrator service', () => {
       },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     const updated: Array<{ id: string; status: string }> = [];
@@ -109,8 +115,10 @@ describe('moduleOrchestrator service', () => {
       },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     (Module as any).findByIdAndUpdate = async () => {
@@ -139,8 +147,10 @@ describe('moduleOrchestrator service', () => {
       lastHandshake: new Date(),
     }));
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     (Module as any).findByIdAndUpdate = async () => {};
@@ -167,11 +177,13 @@ describe('moduleOrchestrator service', () => {
     }));
     let findCalls = 0;
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => {
-          findCalls++;
-          return Promise.resolve(modules.slice(s, s + l));
-        },
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => {
+            findCalls++;
+            return Promise.resolve(modules.slice(s, s + l));
+          },
+        }),
       }),
     });
     const updated: string[] = [];
@@ -186,13 +198,45 @@ describe('moduleOrchestrator service', () => {
     assert.equal(updated.length, modules.length);
   });
 
+  it('sorts modules by _id for stable pagination', async () => {
+    const modules = [
+      { _id: 'b', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
+      { _id: 'a', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+      { _id: 'c', endpoints: { rest: 'http://m3' }, lastHandshake: new Date() },
+    ];
+    let sortOptions: any = null;
+    (Module as any).find = () => ({
+      sort: (s: any) => {
+        sortOptions = s;
+        modules.sort((x, y) => String(x._id).localeCompare(String(y._id)));
+        return {
+          skip: (sk: number) => ({
+            limit: (l: number) => Promise.resolve(modules.slice(sk, sk + l)),
+          }),
+        };
+      },
+    });
+    const processed: string[] = [];
+    (Module as any).findByIdAndUpdate = async (id: string) => {
+      processed.push(String(id));
+    };
+    global.fetch = async () => ({ ok: true }) as any;
+
+    await checkModules();
+
+    assert.deepEqual(sortOptions, { _id: 1 });
+    assert.deepEqual(processed, ['a', 'b', 'c']);
+  });
+
   it('aborts ping after pingTimeoutMs', async () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     (Module as any).findByIdAndUpdate = async () => {};
@@ -217,8 +261,10 @@ describe('moduleOrchestrator service', () => {
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
     (Module as any).find = () => ({
-      skip: (s: number) => ({
-        limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+      sort: () => ({
+        skip: (s: number) => ({
+          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
+        }),
       }),
     });
     (Module as any).findByIdAndUpdate = async () => {};

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -143,6 +143,7 @@ export async function checkModules(
   let skip = 0;
   while (true) {
     const modules = await Module.find({ deletedAt: { $exists: false } })
+      .sort({ _id: 1 })
       .skip(skip)
       .limit(batchSize);
     if (modules.length === 0) break;

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -15,15 +15,18 @@ const emitted: Array<{ event: string; moduleId: string }> = [];
 let modules: any[] = [];
 
 (Module as any).find = (filter: any = {}) => ({
-  skip: (s: number) => ({
-    limit: (l: number) =>
-      Promise.resolve(
-        modules
-          .filter((m) =>
-            filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true
-          )
-          .slice(s, s + l)
-      ),
+  sort: () => ({
+    skip: (s: number) => ({
+      limit: (l: number) =>
+        Promise.resolve(
+          modules
+            .filter((m) =>
+              filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true
+            )
+            .sort((a, b) => String(a._id).localeCompare(String(b._id)))
+            .slice(s, s + l)
+        ),
+    }),
   }),
 });
 (Module as any).findByIdAndUpdate = async (id: any, update: any) => {

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -30,15 +30,17 @@ describe('module orchestrator cycle control', () => {
     let maxRunning = 0;
     let calls = 0;
     (Module as any).find = () => ({
-      skip: (_s: number) => ({
-        limit: async (_l: number) => {
-          running++;
-          maxRunning = Math.max(maxRunning, running);
-          await wait(80);
-          running--;
-          calls++;
-          return [];
-        },
+      sort: () => ({
+        skip: (_s: number) => ({
+          limit: async (_l: number) => {
+            running++;
+            maxRunning = Math.max(maxRunning, running);
+            await wait(80);
+            running--;
+            calls++;
+            return [];
+          },
+        }),
       }),
     });
 
@@ -56,12 +58,14 @@ describe('module orchestrator cycle control', () => {
   it('recovers and schedules new cycle after errors', async () => {
     let calls = 0;
     (Module as any).find = () => ({
-      skip: (_s: number) => ({
-        limit: async (_l: number) => {
-          calls++;
-          if (calls === 1) throw new Error('fail');
-          return [];
-        },
+      sort: () => ({
+        skip: (_s: number) => ({
+          limit: async (_l: number) => {
+            calls++;
+            if (calls === 1) throw new Error('fail');
+            return [];
+          },
+        }),
       }),
     });
 
@@ -78,12 +82,14 @@ describe('module orchestrator cycle control', () => {
   it('stops scheduling when stopped mid-cycle', async () => {
     let calls = 0;
     (Module as any).find = () => ({
-      skip: (_s: number) => ({
-        limit: async (_l: number) => {
-          calls++;
-          await wait(50);
-          return [];
-        },
+      sort: () => ({
+        skip: (_s: number) => ({
+          limit: async (_l: number) => {
+            calls++;
+            await wait(50);
+            return [];
+          },
+        }),
       }),
     });
 
@@ -108,8 +114,10 @@ describe('module orchestrator cycle control', () => {
         },
       ];
       (Module as any).find = () => ({
-        skip: (s: number) => ({
-          limit: async (_l: number) => modules.slice(s, s + _l),
+        sort: () => ({
+          skip: (s: number) => ({
+            limit: async (_l: number) => modules.slice(s, s + _l),
+          }),
         }),
       });
       (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
@@ -145,8 +153,10 @@ describe('module orchestrator cycle control', () => {
         },
       ];
       (Module as any).find = () => ({
-        skip: (s: number) => ({
-          limit: async (_l: number) => modules.slice(s, s + _l),
+        sort: () => ({
+          skip: (s: number) => ({
+            limit: async (_l: number) => modules.slice(s, s + _l),
+          }),
         }),
       });
       (Module as any).findByIdAndUpdate = async (id: any, update: any) => {


### PR DESCRIPTION
## Summary
- sort modules by `_id` before pagination
- verify sorted iteration with new unit test
- record change in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a79cd9a7883338dbbaf6c23b8ec4b