### PR TITLE
Use cursor-based pagination in module orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator now pings modules in parallel before pruning.
 - Module orchestrator pings now have a timeout using `AbortController` to mark modules offline on timeout.
 - Module orchestrator uses the logging utility instead of `console`.
+- Module orchestrator paginates using `_id` cursors instead of `skip` for improved efficiency.
 
 ### Fixed
 - Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -10,6 +10,31 @@ import * as eventBus from '../../messaging/eventBus';
 
 let originalFetch: typeof fetch;
 
+function createFindStub(
+  modules: any[],
+  opts: { onCall?: () => void; onSort?: (s: any) => void } = {}
+) {
+  return (query: any = {}) => {
+    opts.onCall?.();
+    return {
+      sort: (s: any) => {
+        opts.onSort?.(s);
+        return {
+          limit: (l: number) => {
+            const filtered = modules
+              .filter(
+                (m) => !query._id || Number(m._id) > Number(query._id.$gt)
+              )
+              .sort((a, b) => String(a._id).localeCompare(String(b._id)))
+              .slice(0, l);
+            return Promise.resolve(filtered);
+          },
+        };
+      },
+    };
+  };
+}
+
 beforeEach(() => {
   originalFetch = global.fetch;
   (eventBus as any).publish = async () => {};
@@ -25,13 +50,7 @@ describe('moduleOrchestrator service', () => {
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     const updated: string[] = [];
     (Module as any).findByIdAndUpdate = async (id: string) => {
       updated.push(String(id));
@@ -49,13 +68,7 @@ describe('moduleOrchestrator service', () => {
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date(0) },
       { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     const updated: string[] = [];
     (Module as any).findByIdAndUpdate = async (id: string) => {
       updated.push(String(id));
@@ -83,13 +96,7 @@ describe('moduleOrchestrator service', () => {
         status: 'offline',
       },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     const updated: Array<{ id: string; status: string }> = [];
     (Module as any).findByIdAndUpdate = async (id: string, update: any) => {
       updated.push({ id: String(id), status: update.status });
@@ -114,13 +121,7 @@ describe('moduleOrchestrator service', () => {
         lastHandshake: new Date(0),
       },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     (Module as any).findByIdAndUpdate = async () => {
       throw new Error('should not update');
     };
@@ -146,13 +147,7 @@ describe('moduleOrchestrator service', () => {
       endpoints: { rest: `http://m${i}` },
       lastHandshake: new Date(),
     }));
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     (Module as any).findByIdAndUpdate = async () => {};
     let active = 0;
     let maxActive = 0;
@@ -176,15 +171,10 @@ describe('moduleOrchestrator service', () => {
       lastHandshake: new Date(),
     }));
     let findCalls = 0;
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => {
-            findCalls++;
-            return Promise.resolve(modules.slice(s, s + l));
-          },
-        }),
-      }),
+    (Module as any).find = createFindStub(modules, {
+      onCall: () => {
+        findCalls++;
+      },
     });
     const updated: string[] = [];
     (Module as any).findByIdAndUpdate = async (id: string) => {
@@ -205,15 +195,9 @@ describe('moduleOrchestrator service', () => {
       { _id: 'c', endpoints: { rest: 'http://m3' }, lastHandshake: new Date() },
     ];
     let sortOptions: any = null;
-    (Module as any).find = () => ({
-      sort: (s: any) => {
+    (Module as any).find = createFindStub(modules, {
+      onSort: (s) => {
         sortOptions = s;
-        modules.sort((x, y) => String(x._id).localeCompare(String(y._id)));
-        return {
-          skip: (sk: number) => ({
-            limit: (l: number) => Promise.resolve(modules.slice(sk, sk + l)),
-          }),
-        };
       },
     });
     const processed: string[] = [];
@@ -232,13 +216,7 @@ describe('moduleOrchestrator service', () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     (Module as any).findByIdAndUpdate = async () => {};
     const durations: number[] = [];
     global.fetch = async (_: string, init: any) =>
@@ -260,13 +238,7 @@ describe('moduleOrchestrator service', () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
     ];
-    (Module as any).find = () => ({
-      sort: () => ({
-        skip: (s: number) => ({
-          limit: (l: number) => Promise.resolve(modules.slice(s, s + l)),
-        }),
-      }),
-    });
+    (Module as any).find = createFindStub(modules);
     (Module as any).findByIdAndUpdate = async () => {};
     const durations: number[] = [];
     global.fetch = async (_: string, init: any) =>

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -140,15 +140,18 @@ export async function checkModules(
     }
   }
 
-  let skip = 0;
+  let lastId: any | null = null;
   while (true) {
-    const modules = await Module.find({ deletedAt: { $exists: false } })
+    const query: any = { deletedAt: { $exists: false } };
+    if (lastId) {
+      query._id = { $gt: lastId };
+    }
+    const modules = await Module.find(query)
       .sort({ _id: 1 })
-      .skip(skip)
       .limit(batchSize);
     if (modules.length === 0) break;
     await processBatch(modules);
-    skip += modules.length;
+    lastId = modules[modules.length - 1]._id;
   }
 }
 

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -16,17 +16,16 @@ let modules: any[] = [];
 
 (Module as any).find = (filter: any = {}) => ({
   sort: () => ({
-    skip: (s: number) => ({
-      limit: (l: number) =>
-        Promise.resolve(
-          modules
-            .filter((m) =>
-              filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true
-            )
-            .sort((a, b) => String(a._id).localeCompare(String(b._id)))
-            .slice(s, s + l)
-        ),
-    }),
+    limit: (l: number) =>
+      Promise.resolve(
+        modules
+          .filter((m) =>
+            (filter.deletedAt?.$exists === false ? !('deletedAt' in m) : true) &&
+            (!filter._id || Number(m._id) > Number(filter._id.$gt))
+          )
+          .sort((a, b) => String(a._id).localeCompare(String(b._id)))
+          .slice(0, l)
+      ),
   }),
 });
 (Module as any).findByIdAndUpdate = async (id: any, update: any) => {

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -18,6 +18,28 @@ const emitted: Array<{ event: string; moduleId: string }> = [];
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
+function createFindStub(
+  modules: any[],
+  opts: { onCall?: () => void } = {}
+) {
+  return (query: any = {}) => {
+    opts.onCall?.();
+    return {
+      sort: () => ({
+        limit: (l: number) => {
+          const filtered = modules
+            .filter(
+              (m) => !query._id || Number(m._id) > Number(query._id.$gt)
+            )
+            .sort((a, b) => String(a._id).localeCompare(String(b._id)))
+            .slice(0, l);
+          return Promise.resolve(filtered);
+        },
+      }),
+    };
+  };
+}
+
 beforeEach(async () => {
   stopModuleOrchestrator();
   await wait(50);
@@ -31,16 +53,14 @@ describe('module orchestrator cycle control', () => {
     let calls = 0;
     (Module as any).find = () => ({
       sort: () => ({
-        skip: (_s: number) => ({
-          limit: async (_l: number) => {
-            running++;
-            maxRunning = Math.max(maxRunning, running);
-            await wait(80);
-            running--;
-            calls++;
-            return [];
-          },
-        }),
+        limit: async () => {
+          running++;
+          maxRunning = Math.max(maxRunning, running);
+          await wait(80);
+          running--;
+          calls++;
+          return [];
+        },
       }),
     });
 
@@ -59,13 +79,11 @@ describe('module orchestrator cycle control', () => {
     let calls = 0;
     (Module as any).find = () => ({
       sort: () => ({
-        skip: (_s: number) => ({
-          limit: async (_l: number) => {
-            calls++;
-            if (calls === 1) throw new Error('fail');
-            return [];
-          },
-        }),
+        limit: async () => {
+          calls++;
+          if (calls === 1) throw new Error('fail');
+          return [];
+        },
       }),
     });
 
@@ -83,13 +101,11 @@ describe('module orchestrator cycle control', () => {
     let calls = 0;
     (Module as any).find = () => ({
       sort: () => ({
-        skip: (_s: number) => ({
-          limit: async (_l: number) => {
-            calls++;
-            await wait(50);
-            return [];
-          },
-        }),
+        limit: async () => {
+          calls++;
+          await wait(50);
+          return [];
+        },
       }),
     });
 
@@ -113,13 +129,7 @@ describe('module orchestrator cycle control', () => {
           status: 'offline',
         },
       ];
-      (Module as any).find = () => ({
-        sort: () => ({
-          skip: (s: number) => ({
-            limit: async (_l: number) => modules.slice(s, s + _l),
-          }),
-        }),
-      });
+      (Module as any).find = createFindStub(modules);
       (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
         const mod = modules.find((m) => m._id === id);
         Object.assign(mod!, update);
@@ -152,13 +162,7 @@ describe('module orchestrator cycle control', () => {
           status: 'online',
         },
       ];
-      (Module as any).find = () => ({
-        sort: () => ({
-          skip: (s: number) => ({
-            limit: async (_l: number) => modules.slice(s, s + _l),
-          }),
-        }),
-      });
+      (Module as any).find = createFindStub(modules);
       (Module as any).findByIdAndUpdate = async (id: any, update: any) => {
         const mod = modules.find((m) => m._id === id);
         Object.assign(mod!, update);


### PR DESCRIPTION
## Summary
- replace skip-based pagination with `_id` cursor for module orchestration
- update tests to mock cursor-based queries
- document pagination change in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7c427de8833383b3369b8064b0c4