### PR TITLE
Check module status before emitting offline event

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -31,11 +31,14 @@ export async function checkModules(
       pingUrl = new URL('/ping', mod.endpoints.rest).toString();
     } catch (err) {
       logger.error('Invalid ping URL for module', mod._id, err);
+      const wasOffline = mod.status === 'offline';
       await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
-      try {
-        await eventBus.publish('module.offline', { moduleId: String(mod._id) });
-      } catch (err) {
-        logger.error('Failed to publish module.offline event', err);
+      if (!wasOffline) {
+        try {
+          await eventBus.publish('module.offline', { moduleId: String(mod._id) });
+        } catch (err) {
+          logger.error('Failed to publish module.offline event', err);
+        }
       }
       return null;
     }

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -112,6 +112,23 @@ describe('moduleOrchestrator service', () => {
     assert.deepEqual(emitted, [{ event: 'module.offline', moduleId: '4' }]);
   });
 
+  it('does not emit module.offline for invalid URL when already offline', async () => {
+    modules = [
+      {
+        _id: '5',
+        endpoints: { rest: 'invalid-url' },
+        status: 'offline',
+      },
+    ];
+    emitted.length = 0;
+
+    await checkModules(undefined, 50);
+    const m5 = modules.find((m) => m._id === '5');
+    assert(m5);
+    assert.equal(m5.status, 'offline');
+    assert.deepEqual(emitted, []);
+  });
+
   it('does not process modules with deletedAt', async () => {
     modules = [
       {


### PR DESCRIPTION
## Summary
- avoid publishing module.offline twice by checking prior status before emitting
- add regression tests for offline event behavior with invalid ping URLs

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7eb289848333922b29fc7c615dc2