### PR TITLE
Log ping failures in module orchestrator

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -53,6 +53,7 @@ export async function checkModules(
         online = false;
       } else {
         online = false;
+        logger.error('Ping failed', err);
       }
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- log non-AbortError ping failures in module orchestrator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a806a433883339d8ade5a8832ada9