### PR TITLE
docs: add module orchestrator guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator service to monitor registered modules and prune stale entries.
 - Module orchestrator now emits `module.online`, `module.offline`, and `module.removed` events with corresponding logs.
 - Centralized logging utility.
+- Documentation for module orchestrator options and events.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,15 @@ flowchart LR
 
 ---
 
+## 🔄 Orquestador de Módulos
+
+El orquestador verifica periódicamente los módulos registrados, actualiza su estado y
+puede eliminar los que permanezcan offline demasiado tiempo. Consulta
+[docs/module-orchestrator.md](./docs/module-orchestrator.md) para conocer las opciones de
+configuración y los eventos emitidos.
+
+---
+
 ## 🧾 Contrato y Versionado de Módulos
 
 Cada módulo debe proporcionar un **manifest** JSON con metadatos clave (nombre, versión, endpoints, esquemas y eventos). El Módulo Central valida este manifest con AJV y lo almacena en un **Schema Registry** para facilitar la compatibilidad entre versiones.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -1,0 +1,18 @@
+# Module Orchestrator
+
+El orquestador de módulos verifica periódicamente el estado de los módulos registrados.
+Actualiza su estado, elimina los que permanecen inactivos demasiado tiempo y publica eventos
+para notificar cambios de disponibilidad.
+
+## Opciones
+
+- `intervalMs` – tiempo en milisegundos entre cada ciclo de verificación (por defecto 60 000 ms).
+- `pruneOfflineMs` – elimina un módulo si supera este umbral de tiempo inactivo.
+- `maxConcurrentPings` – cantidad máxima de pings que se ejecutan en paralelo (por defecto 10).
+- `pingTimeoutMs` – tiempo máximo de espera de cada ping antes de marcar al módulo como offline (por defecto 5 000 ms).
+
+## Eventos emitidos
+
+- `module.online` – un módulo respondió al ping y su estado cambió a `online`.
+- `module.offline` – un módulo no respondió al ping o tiene un endpoint inválido.
+- `module.removed` – se eliminó un módulo tras permanecer offline más allá de `pruneOfflineMs`.


### PR DESCRIPTION
## Summary
- document module orchestrator responsibilities, options and emitted events
- reference orchestrator guide from README
- log documentation addition in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a8535abf483339388ec0b1f23c074