### PR TITLE
Log module id on ping failure

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../moduleOrchestrator';
 import Module from '../../models/Module';
 import * as eventBus from '../../messaging/eventBus';
+import logger from '../../lib/logger';
 
 let originalFetch: typeof fetch;
 
@@ -85,6 +86,32 @@ describe('moduleOrchestrator service', () => {
 
     assert.deepEqual(deleted, ['1']);
     assert.deepEqual(updated, ['2']);
+  });
+
+  it('logs module id when ping fails', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    const error = new Error('fail');
+    global.fetch = async () => {
+      throw error;
+    };
+    const logs: any[] = [];
+    const originalError = logger.error;
+    logger.error = (...args: unknown[]) => {
+      logs.push(args);
+    };
+
+    await checkModules();
+
+    logger.error = originalError;
+    assert.ok(
+      logs.some(
+        (args) => args[0] === 'Ping failed' && args[1] === '1' && args[2] === error
+      )
+    );
   });
 
   it('publishes module.online when an offline module responds', async () => {

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -53,7 +53,7 @@ export async function checkModules(
         online = false;
       } else {
         online = false;
-        logger.error('Ping failed', err);
+        logger.error('Ping failed', mod._id, err);
       }
     } finally {
       clearTimeout(timeout);


### PR DESCRIPTION
## Summary
- include module id in ping failure logs
- test ping failure logging for module orchestrator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a869bb6088333ae5853cac4d661f8