### PR TITLE
Record handshake on failed module pings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator publishes `module.offline` when ping URL is invalid.
 - Module orchestrator runs sequentially, avoiding overlapping cycles and resetting its state on errors.
 - Module orchestrator sorts modules by `_id` before pagination to ensure stable ordering.
+- Module orchestrator sets `lastHandshake` when pings fail or URLs are invalid, enabling pruning of modules without previous handshakes.
 
 ## [0.5.2] - 2025-08-11
 

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -4,6 +4,10 @@ El orquestador de módulos verifica periódicamente el estado de los módulos re
 Actualiza su estado, elimina los que permanecen inactivos demasiado tiempo y publica eventos
 para notificar cambios de disponibilidad.
 
+Si un ping falla o el endpoint es inválido y el módulo no tiene `lastHandshake`,
+el orquestador lo marca como offline y registra la hora actual para permitir su
+eliminación en ciclos posteriores.
+
 ## Opciones
 
 - `intervalMs` – tiempo en milisegundos entre cada ciclo de verificación (por defecto 60 000 ms).

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -168,6 +168,35 @@ describe('moduleOrchestrator service', () => {
     assert.deepEqual(events, [{ event: 'module.removed', payload: { moduleId: '1' } }]);
   });
 
+  it('prunes modules without lastHandshake on the next cycle', async () => {
+    const modules = [
+      {
+        _id: '1',
+        endpoints: { rest: 'http://m1' },
+        status: 'online',
+      },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async (id: string, update: any) => {
+      const mod = modules.find((m) => String(m._id) === String(id));
+      if (mod) Object.assign(mod, update);
+    };
+    const deleted: string[] = [];
+    (Module as any).deleteOne = async (query: any) => {
+      deleted.push(String(query._id));
+    };
+    global.fetch = async () => ({ ok: false }) as any;
+
+    await checkModules(1);
+    assert.ok(modules[0].lastHandshake instanceof Date);
+    assert.deepEqual(deleted, []);
+
+    await new Promise((r) => setTimeout(r, 2));
+    await checkModules(1);
+
+    assert.deepEqual(deleted, ['1']);
+  });
+
   it('respects maxConcurrentPings limit', async () => {
     const modules = Array.from({ length: 20 }, (_, i) => ({
       _id: String(i),

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -32,7 +32,11 @@ export async function checkModules(
     } catch (err) {
       logger.error('Invalid ping URL for module', mod._id, err);
       const wasOffline = mod.status === 'offline';
-      await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+      const update: any = { status: 'offline' };
+      if (!mod.lastHandshake) {
+        update.lastHandshake = new Date();
+      }
+      await Module.findByIdAndUpdate(mod._id, update);
       if (!wasOffline) {
         try {
           await eventBus.publish('module.offline', { moduleId: String(mod._id) });
@@ -124,8 +128,12 @@ export async function checkModules(
           continue;
         }
         const wasOffline = mod.status === 'offline';
+        const update: any = { status: 'offline' };
+        if (!mod.lastHandshake) {
+          update.lastHandshake = new Date();
+        }
         try {
-          await Module.findByIdAndUpdate(mod._id, { status: 'offline' });
+          await Module.findByIdAndUpdate(mod._id, update);
         } catch (err) {
           logger.error('Failed to update module to offline', mod._id, err);
           continue;


### PR DESCRIPTION
## Summary
- Record `lastHandshake` when ping URL is invalid or ping fails so modules without handshakes can later be pruned
- Add regression test ensuring modules without `lastHandshake` are removed after the next offline check
- Document new pruning behavior and note it in the changelog

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a87b93ddc83338f7b4acaaa0f6c52