### PR TITLE
Allow configuring check batch size

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -313,4 +313,26 @@ describe('moduleOrchestrator service', () => {
     assert.ok(durations[0] >= 10);
     assert.ok(durations[0] < 50);
   });
+
+  it('passes batchSize from startModuleOrchestrator to checkModules', async () => {
+    const modules = Array.from({ length: 120 }, (_, i) => ({
+      _id: String(i),
+      endpoints: { rest: `http://m${i}` },
+      lastHandshake: new Date(),
+    }));
+    let findCalls = 0;
+    (Module as any).find = createFindStub(modules, {
+      onCall: () => {
+        findCalls++;
+      },
+    });
+    (Module as any).findByIdAndUpdate = async () => {};
+    global.fetch = async () => ({ ok: true }) as any;
+
+    startModuleOrchestrator({ intervalMs: 1_000, batchSize: 50 });
+    await new Promise((r) => setTimeout(r, 50));
+    stopModuleOrchestrator();
+
+    assert.equal(findCalls, 4);
+  });
 });

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -11,6 +11,7 @@ export interface OrchestratorOptions {
   pruneOfflineMs?: number;
   maxConcurrentPings?: number;
   pingTimeoutMs?: number;
+  batchSize?: number;
 }
 
 /**
@@ -20,10 +21,10 @@ export interface OrchestratorOptions {
 export async function checkModules(
   pruneOfflineMs?: number,
   pingTimeoutMs = 5_000,
-  maxConcurrentPings = 10
+  maxConcurrentPings = 10,
+  batchSize = 100
 ) {
   const now = Date.now();
-  const batchSize = 100;
 
   async function pingModule(mod: any) {
     let pingUrl: string;
@@ -176,6 +177,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     pruneOfflineMs,
     maxConcurrentPings,
     pingTimeoutMs,
+    batchSize = 100,
   } = options;
   if (isActive) return;
   isActive = true;
@@ -184,7 +186,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     if (!isActive || isRunning) return;
     isRunning = true;
     try {
-      await checkModules(pruneOfflineMs, pingTimeoutMs, maxConcurrentPings);
+      await checkModules(pruneOfflineMs, pingTimeoutMs, maxConcurrentPings, batchSize);
     } catch (err) {
       logger.error('Module orchestration error', err);
     } finally {


### PR DESCRIPTION
## Summary
- add optional `batchSize` to orchestrator options and `checkModules`
- pass `batchSize` from `startModuleOrchestrator`
- test orchestration with custom batch size

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aa309553883338fcb21632a6dcd8f