### PR TITLE
Validate module orchestrator options

### DIFF
--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -43,6 +43,7 @@ beforeEach(() => {
 
 afterEach(() => {
   global.fetch = originalFetch;
+  stopModuleOrchestrator();
 });
 
 describe('moduleOrchestrator service', () => {
@@ -334,5 +335,37 @@ describe('moduleOrchestrator service', () => {
     stopModuleOrchestrator();
 
     assert.equal(findCalls, 4);
+  });
+
+  it('throws if maxConcurrentPings is not positive in checkModules', async () => {
+    await assert.rejects(() => checkModules(undefined, undefined, 0), {
+      message: 'maxConcurrentPings must be a positive number',
+    });
+  });
+
+  it('throws if batchSize is not positive in checkModules', async () => {
+    await assert.rejects(() => checkModules(undefined, undefined, undefined, 0), {
+      message: 'batchSize must be a positive number',
+    });
+  });
+
+  it('throws if intervalMs is not positive in startModuleOrchestrator', () => {
+    assert.throws(() => startModuleOrchestrator({ intervalMs: 0 }), {
+      message: 'intervalMs must be a positive number',
+    });
+  });
+
+  it('throws if maxConcurrentPings is not positive in startModuleOrchestrator', () => {
+    assert.throws(
+      () => startModuleOrchestrator({ intervalMs: 1_000, maxConcurrentPings: 0 }),
+      { message: 'maxConcurrentPings must be a positive number' }
+    );
+  });
+
+  it('throws if batchSize is not positive in startModuleOrchestrator', () => {
+    assert.throws(
+      () => startModuleOrchestrator({ intervalMs: 1_000, batchSize: 0 }),
+      { message: 'batchSize must be a positive number' }
+    );
   });
 });

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -26,6 +26,13 @@ export async function checkModules(
   maxConcurrentPings = 10,
   batchSize = 100
 ) {
+  if (typeof maxConcurrentPings !== 'number' || maxConcurrentPings <= 0) {
+    throw new Error('maxConcurrentPings must be a positive number');
+  }
+  if (typeof batchSize !== 'number' || batchSize <= 0) {
+    throw new Error('batchSize must be a positive number');
+  }
+
   const now = Date.now();
 
   async function pingModule(mod: IModule): Promise<{ mod: IModule; online: boolean } | null> {
@@ -181,6 +188,18 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     pingTimeoutMs,
     batchSize = 100,
   } = options;
+  if (typeof intervalMs !== 'number' || intervalMs <= 0) {
+    throw new Error('intervalMs must be a positive number');
+  }
+  if (
+    maxConcurrentPings !== undefined &&
+    (typeof maxConcurrentPings !== 'number' || maxConcurrentPings <= 0)
+  ) {
+    throw new Error('maxConcurrentPings must be a positive number');
+  }
+  if (typeof batchSize !== 'number' || batchSize <= 0) {
+    throw new Error('batchSize must be a positive number');
+  }
   if (isActive) return;
   isActive = true;
 


### PR DESCRIPTION
## Summary
- ensure module orchestrator options are positive numbers
- add tests for invalid orchestrator configuration

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689abcc4acb08333b74266afd4b09548