### PR TITLE
docs: document batchSize option

### DIFF
--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -14,6 +14,7 @@ eliminación en ciclos posteriores.
 - `pruneOfflineMs` – elimina un módulo si supera este umbral de tiempo inactivo.
 - `maxConcurrentPings` – cantidad máxima de pings que se ejecutan en paralelo (por defecto 10).
 - `pingTimeoutMs` – tiempo máximo de espera de cada ping antes de marcar al módulo como offline (por defecto 5 000 ms).
+- `batchSize` – tamaño de lote al paginar módulos (por defecto 100).
 
 ## Eventos emitidos
 


### PR DESCRIPTION
## Summary
- document `batchSize` option in module orchestrator

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689abf98eec08333a075c5d4acc0abfb