### PR TITLE
fix orchestrator ping path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator runs sequentially, avoiding overlapping cycles and resetting its state on errors.
 - Module orchestrator sorts modules by `_id` before pagination to ensure stable ordering.
 - Module orchestrator sets `lastHandshake` when pings fail or URLs are invalid, enabling pruning of modules without previous handshakes.
+- Module orchestrator now preserves subroutes when constructing ping URLs.
 
 ## [0.5.2] - 2025-08-11
 

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -38,7 +38,10 @@ export async function checkModules(
   async function pingModule(mod: IModule): Promise<{ mod: IModule; online: boolean } | null> {
     let pingUrl: string;
     try {
-      pingUrl = new URL('/ping', mod.endpoints.rest).toString();
+      const baseUrl = mod.endpoints.rest.endsWith('/')
+        ? mod.endpoints.rest
+        : `${mod.endpoints.rest}/`;
+      pingUrl = new URL('ping', baseUrl).toString();
     } catch (err) {
       logger.error('Invalid ping URL for module', mod._id, err);
       const wasOffline = mod.status === 'offline';

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -135,13 +135,20 @@ describe('module orchestrator cycle control', () => {
         Object.assign(mod!, update);
         return mod;
       };
-      (global as any).fetch = async () => ({ ok: true } as any);
+      const fetched: string[] = [];
+      (global as any).fetch = async (url: string) => {
+        fetched.push(String(url));
+        return { ok: true } as any;
+      };
 
       await checkModules(undefined, 50);
+      assert.equal(fetched[0], 'https://m1.local/api/ping');
       assert.deepEqual(emitted, [{ event: 'module.online', moduleId: '1' }]);
 
       emitted.length = 0;
+      fetched.length = 0;
       await checkModules(undefined, 50);
+      assert.equal(fetched[0], 'https://m1.local/api/ping');
       assert.deepEqual(emitted, []);
     } finally {
       (Module as any).find = originalFind;


### PR DESCRIPTION
## Summary
- preserve module subroutes when building ping URL
- test pinging modules with subroute endpoints
- document ping URL fix in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ac4d91b688333b86884c7b5721755