### PR TITLE
Validate ping timeout and prune thresholds

### DIFF
--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -11,9 +11,9 @@ eliminación en ciclos posteriores.
 ## Opciones
 
 - `intervalMs` – tiempo en milisegundos entre cada ciclo de verificación (por defecto 60 000 ms).
-- `pruneOfflineMs` – elimina un módulo si supera este umbral de tiempo inactivo.
+- `pruneOfflineMs` – elimina un módulo si supera este umbral de tiempo inactivo. Debe ser un número positivo.
 - `maxConcurrentPings` – cantidad máxima de pings que se ejecutan en paralelo (por defecto 10).
-- `pingTimeoutMs` – tiempo máximo de espera de cada ping antes de marcar al módulo como offline (por defecto 5 000 ms).
+- `pingTimeoutMs` – tiempo máximo de espera de cada ping antes de marcar al módulo como offline. Debe ser un número positivo (por defecto 5 000 ms).
 - `batchSize` – tamaño de lote al paginar módulos (por defecto 100).
 
 ## Eventos emitidos

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -343,6 +343,18 @@ describe('moduleOrchestrator service', () => {
     });
   });
 
+  it('throws if pruneOfflineMs is not positive in checkModules', async () => {
+    await assert.rejects(() => checkModules(0), {
+      message: 'pruneOfflineMs must be a positive number',
+    });
+  });
+
+  it('throws if pingTimeoutMs is not positive in checkModules', async () => {
+    await assert.rejects(() => checkModules(undefined, 0), {
+      message: 'pingTimeoutMs must be a positive number',
+    });
+  });
+
   it('throws if batchSize is not positive in checkModules', async () => {
     await assert.rejects(() => checkModules(undefined, undefined, undefined, 0), {
       message: 'batchSize must be a positive number',
@@ -359,6 +371,20 @@ describe('moduleOrchestrator service', () => {
     assert.throws(
       () => startModuleOrchestrator({ intervalMs: 1_000, maxConcurrentPings: 0 }),
       { message: 'maxConcurrentPings must be a positive number' }
+    );
+  });
+
+  it('throws if pruneOfflineMs is not positive in startModuleOrchestrator', () => {
+    assert.throws(
+      () => startModuleOrchestrator({ intervalMs: 1_000, pruneOfflineMs: 0 }),
+      { message: 'pruneOfflineMs must be a positive number' }
+    );
+  });
+
+  it('throws if pingTimeoutMs is not positive in startModuleOrchestrator', () => {
+    assert.throws(
+      () => startModuleOrchestrator({ intervalMs: 1_000, pingTimeoutMs: 0 }),
+      { message: 'pingTimeoutMs must be a positive number' }
     );
   });
 

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -26,6 +26,15 @@ export async function checkModules(
   maxConcurrentPings = 10,
   batchSize = 100
 ) {
+  if (
+    pruneOfflineMs !== undefined &&
+    (typeof pruneOfflineMs !== 'number' || pruneOfflineMs <= 0)
+  ) {
+    throw new Error('pruneOfflineMs must be a positive number');
+  }
+  if (typeof pingTimeoutMs !== 'number' || pingTimeoutMs <= 0) {
+    throw new Error('pingTimeoutMs must be a positive number');
+  }
   if (typeof maxConcurrentPings !== 'number' || maxConcurrentPings <= 0) {
     throw new Error('maxConcurrentPings must be a positive number');
   }
@@ -193,6 +202,18 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
   } = options;
   if (typeof intervalMs !== 'number' || intervalMs <= 0) {
     throw new Error('intervalMs must be a positive number');
+  }
+  if (
+    pruneOfflineMs !== undefined &&
+    (typeof pruneOfflineMs !== 'number' || pruneOfflineMs <= 0)
+  ) {
+    throw new Error('pruneOfflineMs must be a positive number');
+  }
+  if (
+    pingTimeoutMs !== undefined &&
+    (typeof pingTimeoutMs !== 'number' || pingTimeoutMs <= 0)
+  ) {
+    throw new Error('pingTimeoutMs must be a positive number');
   }
   if (
     maxConcurrentPings !== undefined &&


### PR DESCRIPTION
## Summary
- ensure pruneOfflineMs and pingTimeoutMs are positive numbers in module orchestrator
- describe valid ranges for pruneOfflineMs and pingTimeoutMs in docs
- add tests for pruneOfflineMs and pingTimeoutMs validations

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689acb57b5488333b4c11c0611bc684d