### PR TITLE
feat: allow custom ping path in orchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator now emits `module.online`, `module.offline`, and `module.removed` events with corresponding logs.
 - Centralized logging utility.
 - Documentation for module orchestrator options and events.
+- Module orchestrator supports custom `pingPath` option.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -15,6 +15,7 @@ eliminación en ciclos posteriores.
 - `maxConcurrentPings` – cantidad máxima de pings que se ejecutan en paralelo (por defecto 10).
 - `pingTimeoutMs` – tiempo máximo de espera de cada ping antes de marcar al módulo como offline. Debe ser un número positivo (por defecto 5 000 ms).
 - `batchSize` – tamaño de lote al paginar módulos (por defecto 100).
+- `pingPath` – ruta a anexar al endpoint `rest` del módulo para realizar el ping (por defecto `ping`).
 
 ## Eventos emitidos
 

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -291,6 +291,23 @@ describe('moduleOrchestrator service', () => {
     assert.ok(durations[0] < 50);
   });
 
+  it('uses custom pingPath when provided', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    let url: string | undefined;
+    global.fetch = async (u: string) => {
+      url = u;
+      return { ok: true } as any;
+    };
+
+    await checkModules(undefined, undefined, undefined, undefined, 'status');
+
+    assert.equal(url, 'http://m1/status');
+  });
+
   it('passes pingTimeoutMs from startModuleOrchestrator to checkModules', async () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
@@ -313,6 +330,25 @@ describe('moduleOrchestrator service', () => {
 
     assert.ok(durations[0] >= 10);
     assert.ok(durations[0] < 50);
+  });
+
+  it('passes pingPath from startModuleOrchestrator to checkModules', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    let url: string | undefined;
+    global.fetch = async (u: string) => {
+      url = u;
+      return { ok: true } as any;
+    };
+
+    startModuleOrchestrator({ intervalMs: 1_000, pingPath: 'health' });
+    await new Promise((r) => setTimeout(r, 50));
+    stopModuleOrchestrator();
+
+    assert.equal(url, 'http://m1/health');
   });
 
   it('passes batchSize from startModuleOrchestrator to checkModules', async () => {
@@ -361,6 +397,13 @@ describe('moduleOrchestrator service', () => {
     });
   });
 
+  it('throws if pingPath is empty in checkModules', async () => {
+    await assert.rejects(
+      () => checkModules(undefined, undefined, undefined, undefined, ''),
+      { message: 'pingPath must be a non-empty string' }
+    );
+  });
+
   it('throws if intervalMs is not positive in startModuleOrchestrator', () => {
     assert.throws(() => startModuleOrchestrator({ intervalMs: 0 }), {
       message: 'intervalMs must be a positive number',
@@ -392,6 +435,13 @@ describe('moduleOrchestrator service', () => {
     assert.throws(
       () => startModuleOrchestrator({ intervalMs: 1_000, batchSize: 0 }),
       { message: 'batchSize must be a positive number' }
+    );
+  });
+
+  it('throws if pingPath is empty in startModuleOrchestrator', () => {
+    assert.throws(
+      () => startModuleOrchestrator({ intervalMs: 1_000, pingPath: '' }),
+      { message: 'pingPath must be a non-empty string' }
     );
   });
 });

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -14,6 +14,7 @@ export interface OrchestratorOptions {
   maxConcurrentPings?: number;
   pingTimeoutMs?: number;
   batchSize?: number;
+  pingPath?: string;
 }
 
 /**
@@ -24,7 +25,8 @@ export async function checkModules(
   pruneOfflineMs?: number,
   pingTimeoutMs = 5_000,
   maxConcurrentPings = 10,
-  batchSize = 100
+  batchSize = 100,
+  pingPath = 'ping'
 ) {
   if (
     pruneOfflineMs !== undefined &&
@@ -41,6 +43,9 @@ export async function checkModules(
   if (typeof batchSize !== 'number' || batchSize <= 0) {
     throw new Error('batchSize must be a positive number');
   }
+  if (typeof pingPath !== 'string' || pingPath.length === 0) {
+    throw new Error('pingPath must be a non-empty string');
+  }
 
   const now = Date.now();
 
@@ -50,7 +55,7 @@ export async function checkModules(
       const baseUrl = mod.endpoints.rest.endsWith('/')
         ? mod.endpoints.rest
         : `${mod.endpoints.rest}/`;
-      pingUrl = new URL('ping', baseUrl).toString();
+      pingUrl = new URL(pingPath, baseUrl).toString();
     } catch (err) {
       logger.error('Invalid ping URL for module', mod._id, err);
       const wasOffline = mod.status === 'offline';
@@ -199,6 +204,7 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     maxConcurrentPings,
     pingTimeoutMs,
     batchSize = 100,
+    pingPath,
   } = options;
   if (typeof intervalMs !== 'number' || intervalMs <= 0) {
     throw new Error('intervalMs must be a positive number');
@@ -224,6 +230,9 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
   if (typeof batchSize !== 'number' || batchSize <= 0) {
     throw new Error('batchSize must be a positive number');
   }
+  if (pingPath !== undefined && (typeof pingPath !== 'string' || pingPath.length === 0)) {
+    throw new Error('pingPath must be a non-empty string');
+  }
   if (isActive) return;
   isActive = true;
 
@@ -231,7 +240,13 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
     if (!isActive || isRunning) return;
     isRunning = true;
     try {
-      await checkModules(pruneOfflineMs, pingTimeoutMs, maxConcurrentPings, batchSize);
+      await checkModules(
+        pruneOfflineMs,
+        pingTimeoutMs,
+        maxConcurrentPings,
+        batchSize,
+        pingPath
+      );
     } catch (err) {
       logger.error('Module orchestration error', err);
     } finally {


### PR DESCRIPTION
## Summary
- allow modules to expose custom ping endpoints via `pingPath`
- document `pingPath` option and update changelog
- test custom ping path and validation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ad5b268c083338f6cdece53b31a21