### PR TITLE
Authorize module pings with integration token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator pings now have a timeout using `AbortController` to mark modules offline on timeout.
 - Module orchestrator uses the logging utility instead of `console`.
 - Module orchestrator paginates using `_id` cursors instead of `skip` for improved efficiency.
+- Module orchestrator includes an `Authorization` header with the module's integration token on ping requests.
 
 ### Fixed
 - Module orchestrator marks modules offline and skips ping when their `rest` endpoint URL is invalid.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -8,6 +8,11 @@ Si un ping falla o el endpoint es inválido y el módulo no tiene `lastHandshake
 el orquestador lo marca como offline y registra la hora actual para permitir su
 eliminación en ciclos posteriores.
 
+## Autenticación
+
+Cada ping incluye un encabezado `Authorization` con el valor `Bearer <integrationToken>`.
+Los módulos deben validar este token antes de responder al ping.
+
 ## Opciones
 
 - `intervalMs` – tiempo en milisegundos entre cada ciclo de verificación (por defecto 60 000 ms).

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -115,6 +115,30 @@ describe('moduleOrchestrator service', () => {
     );
   });
 
+  it('sends Authorization header with integrationToken when pinging', async () => {
+    const token = 'tok123';
+    const modules = [
+      {
+        _id: '1',
+        endpoints: { rest: 'http://m1' },
+        lastHandshake: new Date(),
+        status: 'offline',
+        integrationToken: token,
+      },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    let headers: any;
+    global.fetch = async (_url: string, opts: any) => {
+      headers = opts?.headers;
+      return { ok: true } as any;
+    };
+
+    await checkModules();
+
+    assert.equal(headers?.Authorization, `Bearer ${token}`);
+  });
+
   it('publishes module.online when an offline module responds', async () => {
     const modules = [
       {

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -77,7 +77,12 @@ export async function checkModules(
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), pingTimeoutMs);
     try {
-      const res = await fetch(pingUrl, { signal: controller.signal });
+      const res = await fetch(pingUrl, {
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${mod.integrationToken}`,
+        },
+      });
       online = res.ok;
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {


### PR DESCRIPTION
## Summary
- attach Authorization header with integration token to module ping requests
- test Authorization header behaviour in module orchestrator
- document required Authorization header and note it in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae0ad6e848333bea366cab05b3136