### PR TITLE
Validate module REST endpoint URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Centralized logging utility.
 - Documentation for module orchestrator options and events.
 - Module orchestrator supports custom `pingPath` option.
+- Validation to ensure `endpoints.rest` is a valid URL during module registration.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -4,6 +4,8 @@ El orquestador de módulos verifica periódicamente el estado de los módulos re
 Actualiza su estado, elimina los que permanecen inactivos demasiado tiempo y publica eventos
 para notificar cambios de disponibilidad.
 
+Durante el registro, el campo `endpoints.rest` debe ser una URL válida; de lo contrario, el módulo será rechazado.
+
 Si un ping falla o el endpoint es inválido y el módulo no tiene `lastHandshake`,
 el orquestador lo marca como offline y registra la hora actual para permitir su
 eliminación en ciclos posteriores.

--- a/src/services/__tests__/moduleDiscovery.test.ts
+++ b/src/services/__tests__/moduleDiscovery.test.ts
@@ -60,4 +60,18 @@ describe('moduleDiscovery service', () => {
     assert.deepEqual(second.module.manifest, { b: 2 });
     assert.equal(second.module.version, '1.0.1');
   });
+
+  it('rejects invalid rest endpoint URL', async () => {
+    await assert.rejects(
+      () =>
+        registerModule({
+          name: 'inventory',
+          version: '1.0.0',
+          ownerId: 'u1',
+          manifest: {},
+          endpoints: { rest: 'not-a-url' },
+        }),
+      /endpoints\.rest must be a valid URL/
+    );
+  });
 });

--- a/src/services/moduleDiscovery.ts
+++ b/src/services/moduleDiscovery.ts
@@ -19,6 +19,12 @@ export interface RegisterModuleInput {
  * Returns the created module along with a generated integration token.
  */
 export async function registerModule(data: RegisterModuleInput) {
+  try {
+    new URL(data.endpoints.rest);
+  } catch {
+    throw new Error('endpoints.rest must be a valid URL');
+  }
+
   const existingModule = await Module.findOne({
     name: data.name,
     ownerId: data.ownerId,


### PR DESCRIPTION
## Summary
- validate module registration to require a valid `endpoints.rest` URL
- test module registration rejects invalid REST endpoint
- document REST endpoint URL requirement

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ae3c863a48333ae0c845e7036d012