### PR TITLE
Initialize module orchestrator at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Documentation for module orchestrator options and events.
 - Module orchestrator supports custom `pingPath` option.
 - Validation to ensure `endpoints.rest` is a valid URL during module registration.
+- Instrumentation to start the module orchestrator on server boot and stop it on shutdown.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -4,6 +4,11 @@ El orquestador de módulos verifica periódicamente el estado de los módulos re
 Actualiza su estado, elimina los que permanecen inactivos demasiado tiempo y publica eventos
 para notificar cambios de disponibilidad.
 
+## Inicio y cierre
+
+El orquestador se inicia automáticamente cuando arranca el servidor y se detiene durante el
+apagado para liberar recursos. Esta lógica se encuentra en `instrumentation.ts`.
+
 Durante el registro, el campo `endpoints.rest` debe ser una URL válida; de lo contrario, el módulo será rechazado.
 
 Si un ping falla o el endpoint es inválido y el módulo no tiene `lastHandshake`,

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,0 +1,16 @@
+import * as orchestrator from './src/services/moduleOrchestrator';
+
+export function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  const interval = process.env.MODULE_ORCHESTRATOR_INTERVAL_MS
+    ? Number(process.env.MODULE_ORCHESTRATOR_INTERVAL_MS)
+    : undefined;
+  orchestrator.startModuleOrchestrator(interval ? { intervalMs: interval } : undefined);
+  const shutdown = () => {
+    orchestrator.stopModuleOrchestrator();
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+  process.once('exit', shutdown);
+}
+

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import * as orchestrator from '../services/moduleOrchestrator';
+import { register } from '../../instrumentation';
+
+const origStart = orchestrator.startModuleOrchestrator;
+const origStop = orchestrator.stopModuleOrchestrator;
+
+let started: boolean;
+let stopped: boolean;
+
+describe('instrumentation', () => {
+  beforeEach(() => {
+    started = false;
+    stopped = false;
+    (orchestrator as any).startModuleOrchestrator = () => {
+      started = true;
+    };
+    (orchestrator as any).stopModuleOrchestrator = () => {
+      stopped = true;
+    };
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('exit');
+  });
+
+  afterEach(() => {
+    (orchestrator as any).startModuleOrchestrator = origStart;
+    (orchestrator as any).stopModuleOrchestrator = origStop;
+    process.removeAllListeners('SIGINT');
+    process.removeAllListeners('SIGTERM');
+    process.removeAllListeners('exit');
+    delete process.env.NEXT_RUNTIME;
+  });
+
+  it('starts orchestrator and registers shutdown hooks', () => {
+    process.env.NEXT_RUNTIME = 'nodejs';
+    register();
+    assert.ok(started);
+    process.emit('SIGTERM');
+    assert.ok(stopped);
+  });
+});
+


### PR DESCRIPTION
## Summary
- start the module orchestrator when the Next.js server boots and stop it on shutdown
- document orchestrator startup/shutdown behavior
- note orchestrator startup in changelog and add regression test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ae55ed5348333a8d5dfc2ee2e2348