### PR TITLE
Publish orchestrator cycle metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator supports custom `pingPath` option.
 - Validation to ensure `endpoints.rest` is a valid URL during module registration.
 - Instrumentation to start the module orchestrator on server boot and stop it on shutdown.
+- Module orchestrator publishes `orchestrator.cycle` metrics with online/offline counts and cycle duration.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -34,3 +34,4 @@ Los módulos deben validar este token antes de responder al ping.
 - `module.online` – un módulo respondió al ping y su estado cambió a `online`.
 - `module.offline` – un módulo no respondió al ping o tiene un endpoint inválido.
 - `module.removed` – se eliminó un módulo tras permanecer offline más allá de `pruneOfflineMs`.
+- `orchestrator.cycle` – al finalizar cada ciclo, publica conteos de módulos `online`, `offline` y la duración del proceso en milisegundos.

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -193,6 +193,28 @@ describe('moduleOrchestrator service', () => {
     assert.deepEqual(events, [{ event: 'module.removed', payload: { moduleId: '1' } }]);
   });
 
+  it('emits orchestrator.cycle with metrics', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+      { _id: '2', endpoints: { rest: 'http://m2' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    global.fetch = async (url: string) => ({ ok: !url.includes('m2') }) as any;
+    const events: Array<{ event: string; payload: any }> = [];
+    (eventBus as any).publish = async (event: string, payload: any) => {
+      events.push({ event, payload });
+    };
+
+    await checkModules();
+
+    const metric = events.find((e) => e.event === 'orchestrator.cycle');
+    assert.ok(metric);
+    assert.equal(metric?.payload.online, 1);
+    assert.equal(metric?.payload.offline, 1);
+    assert.ok(typeof metric?.payload.durationMs === 'number');
+  });
+
   it('prunes modules without lastHandshake on the next cycle', async () => {
     const modules = [
       {

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -47,7 +47,10 @@ export async function checkModules(
     throw new Error('pingPath must be a non-empty string');
   }
 
-  const now = Date.now();
+  const startTime = Date.now();
+  const now = startTime;
+  let onlineCount = 0;
+  let offlineCount = 0;
 
   async function pingModule(mod: IModule): Promise<{ mod: IModule; online: boolean } | null> {
     let pingUrl: string;
@@ -71,6 +74,7 @@ export async function checkModules(
           logger.error('Failed to publish module.offline event', err);
         }
       }
+      offlineCount++;
       return null;
     }
     let online = false;
@@ -113,34 +117,36 @@ export async function checkModules(
     );
     await Promise.all(workers);
 
-    for (const result of results) {
-      if (!result) continue;
-      const { mod, online } = result;
-      if (online) {
-        const wasOnline = mod.status === 'online';
-        try {
-          await Module.findByIdAndUpdate(mod._id, {
-            status: 'online',
-            lastHandshake: new Date(),
-          });
-        } catch (err) {
-          logger.error('Failed to update module to online', mod._id, err);
-          continue;
-        }
-        logger.info(`Module ${mod._id} is online`);
-        if (!wasOnline) {
+      for (const result of results) {
+        if (!result) continue;
+        const { mod, online } = result;
+        if (online) {
+          onlineCount++;
+          const wasOnline = mod.status === 'online';
           try {
-            await eventBus.publish('module.online', { moduleId: String(mod._id) });
+            await Module.findByIdAndUpdate(mod._id, {
+              status: 'online',
+              lastHandshake: new Date(),
+            });
           } catch (err) {
-            logger.error('Failed to publish module.online event', err);
+            logger.error('Failed to update module to online', mod._id, err);
+            continue;
           }
-        }
-      } else {
-        if (
-          pruneOfflineMs &&
-          mod.lastHandshake &&
-          now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
-        ) {
+          logger.info(`Module ${mod._id} is online`);
+          if (!wasOnline) {
+            try {
+              await eventBus.publish('module.online', { moduleId: String(mod._id) });
+            } catch (err) {
+              logger.error('Failed to publish module.online event', err);
+            }
+          }
+        } else {
+          offlineCount++;
+          if (
+            pruneOfflineMs &&
+            mod.lastHandshake &&
+            now - new Date(mod.lastHandshake).getTime() > pruneOfflineMs
+          ) {
           try {
             await Module.deleteOne({ _id: mod._id });
           } catch (err) {
@@ -196,6 +202,17 @@ export async function checkModules(
     if (modules.length === 0) break;
     await processBatch(modules);
     lastId = modules[modules.length - 1]._id as Types.ObjectId;
+  }
+
+  const durationMs = Date.now() - startTime;
+  try {
+    await eventBus.publish('orchestrator.cycle', {
+      online: onlineCount,
+      offline: offlineCount,
+      durationMs,
+    });
+  } catch (err) {
+    logger.error('Failed to publish orchestrator.cycle event', err);
   }
 }
 

--- a/src/tests/moduleOrchestrator.test.ts
+++ b/src/tests/moduleOrchestrator.test.ts
@@ -4,12 +4,9 @@ import { checkModules } from '../services/moduleOrchestrator';
 import Module from '../models/Module';
 import * as eventBus from '../messaging/eventBus';
 
-const emitted: Array<{ event: string; moduleId: string }> = [];
-(eventBus as any).publish = async (
-  event: string,
-  payload: { moduleId: string }
-) => {
-  emitted.push({ event, moduleId: payload.moduleId });
+const emitted: Array<{ event: string; moduleId?: string }> = [];
+(eventBus as any).publish = async (event: string, payload: any) => {
+  emitted.push({ event, moduleId: payload?.moduleId });
 };
 
 let modules: any[] = [];
@@ -89,10 +86,13 @@ describe('moduleOrchestrator service', () => {
     assert(m1.lastHandshake instanceof Date);
     assert.equal(m3.status, 'offline');
 
-    assert.deepEqual(emitted, [
-      { event: 'module.online', moduleId: '1' },
-      { event: 'module.removed', moduleId: '2' },
-    ]);
+    assert.deepEqual(
+      emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+      [
+        { event: 'module.online', moduleId: '1' },
+        { event: 'module.removed', moduleId: '2' },
+      ]
+    );
   });
 
   it('emits module.offline when ping URL is invalid', async () => {
@@ -109,7 +109,10 @@ describe('moduleOrchestrator service', () => {
     const m4 = modules.find((m) => m._id === '4');
     assert(m4);
     assert.equal(m4.status, 'offline');
-    assert.deepEqual(emitted, [{ event: 'module.offline', moduleId: '4' }]);
+    assert.deepEqual(
+      emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+      [{ event: 'module.offline', moduleId: '4' }]
+    );
   });
 
   it('does not emit module.offline for invalid URL when already offline', async () => {
@@ -126,7 +129,10 @@ describe('moduleOrchestrator service', () => {
     const m5 = modules.find((m) => m._id === '5');
     assert(m5);
     assert.equal(m5.status, 'offline');
-    assert.deepEqual(emitted, []);
+    assert.deepEqual(
+      emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+      []
+    );
   });
 
   it('does not process modules with deletedAt', async () => {
@@ -153,7 +159,10 @@ describe('moduleOrchestrator service', () => {
     assert.equal(m1.status, 'online');
     assert.equal(m2.status, 'offline');
     assert.equal(m2.lastHandshake, undefined);
-    assert.deepEqual(emitted, [{ event: 'module.online', moduleId: '1' }]);
+    assert.deepEqual(
+      emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+      [{ event: 'module.online', moduleId: '1' }]
+    );
   });
 
   it('limits parallel pings to maxConcurrentPings', async () => {

--- a/src/tests/moduleOrchestratorCycle.test.ts
+++ b/src/tests/moduleOrchestratorCycle.test.ts
@@ -8,12 +8,9 @@ import {
 } from '../services/moduleOrchestrator';
 import * as eventBus from '../messaging/eventBus';
 
-const emitted: Array<{ event: string; moduleId: string }> = [];
-(eventBus as any).publish = async (
-  event: string,
-  payload: { moduleId: string }
-) => {
-  emitted.push({ event, moduleId: payload.moduleId });
+const emitted: Array<{ event: string; moduleId?: string }> = [];
+(eventBus as any).publish = async (event: string, payload: any) => {
+  emitted.push({ event, moduleId: payload?.moduleId });
 };
 
 const wait = (ms: number) => new Promise((res) => setTimeout(res, ms));
@@ -143,13 +140,19 @@ describe('module orchestrator cycle control', () => {
 
       await checkModules(undefined, 50);
       assert.equal(fetched[0], 'https://m1.local/api/ping');
-      assert.deepEqual(emitted, [{ event: 'module.online', moduleId: '1' }]);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        [{ event: 'module.online', moduleId: '1' }]
+      );
 
       emitted.length = 0;
       fetched.length = 0;
       await checkModules(undefined, 50);
       assert.equal(fetched[0], 'https://m1.local/api/ping');
-      assert.deepEqual(emitted, []);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        []
+      );
     } finally {
       (Module as any).find = originalFind;
       (Module as any).findByIdAndUpdate = originalFindByIdAndUpdate;
@@ -178,11 +181,17 @@ describe('module orchestrator cycle control', () => {
       (global as any).fetch = async () => ({ ok: false } as any);
 
       await checkModules(undefined, 50);
-      assert.deepEqual(emitted, [{ event: 'module.offline', moduleId: '1' }]);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        [{ event: 'module.offline', moduleId: '1' }]
+      );
 
       emitted.length = 0;
       await checkModules(undefined, 50);
-      assert.deepEqual(emitted, []);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        []
+      );
     } finally {
       (Module as any).find = originalFind;
       (Module as any).findByIdAndUpdate = originalFindByIdAndUpdate;
@@ -211,7 +220,10 @@ describe('module orchestrator cycle control', () => {
       await checkModules(1, 50);
 
       assert.deepEqual(deleted, ['1']);
-      assert.deepEqual(emitted, [{ event: 'module.removed', moduleId: '1' }]);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        [{ event: 'module.removed', moduleId: '1' }]
+      );
     } finally {
       (Module as any).find = originalFind;
       (Module as any).deleteOne = originalDeleteOne;
@@ -242,7 +254,10 @@ describe('module orchestrator cycle control', () => {
 
       assert.equal(modules[0].status, 'offline');
       assert.ok((modules[0].lastHandshake as any) instanceof Date);
-      assert.deepEqual(emitted, [{ event: 'module.offline', moduleId: '1' }]);
+      assert.deepEqual(
+        emitted.filter((e) => e.event !== 'orchestrator.cycle'),
+        [{ event: 'module.offline', moduleId: '1' }]
+      );
     } finally {
       (Module as any).find = originalFind;
       (Module as any).findByIdAndUpdate = originalFindByIdAndUpdate;


### PR DESCRIPTION
## Summary
- track online/offline modules and cycle duration during orchestration
- publish `orchestrator.cycle` event with metrics
- document new cycle metrics event and cover with tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e9605b6448333b915acb28e4da75b