### PR TITLE
Implement real-time module dashboards per role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Validation to ensure `endpoints.rest` is a valid URL during module registration.
 - Instrumentation to start the module orchestrator on server boot and stop it on shutdown.
 - Module orchestrator publishes `orchestrator.cycle` metrics with online/offline counts and cycle duration.
+- Dashboard views for `owner`, `admin` y `employee` que consumen `getModules` y se actualizan en tiempo real mediante eventos de módulo.
 
 ### Changed
 - Module orchestrator now pings modules in parallel before pruning.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -11,5 +11,9 @@ y redirige automáticamente al panel correspondiente:
 Cada panel utiliza un layout compartido ubicado en `src/app/dashboard/layout.tsx`
 que centraliza el diseño común antes de cargar la vista específica del rol.
 
+Además, cada vista obtiene la lista de módulos mediante `getModules` y se
+suscribe a los eventos `module.online`, `module.offline` y `module.removed`
+para reflejar cambios en tiempo real.
+
 Los usuarios pueden acceder a su panel desde el menú de usuario (AuthMenu)
 mediante la opción **Dashboard**, disponible después de iniciar sesión.

--- a/src/app/api/modules/events/route.ts
+++ b/src/app/api/modules/events/route.ts
@@ -1,0 +1,26 @@
+import { subscribe } from "@/messaging/eventBus";
+
+export async function GET() {
+  const stream = new ReadableStream({
+    async start(controller) {
+      const encoder = new TextEncoder();
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(encoder.encode(`event: ${event}\n`));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+      };
+
+      await subscribe("module.online", (payload) => send("module.online", payload));
+      await subscribe("module.offline", (payload) => send("module.offline", payload));
+      await subscribe("module.removed", (payload) => send("module.removed", payload));
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}
+

--- a/src/app/dashboard/AdminDashboard.tsx
+++ b/src/app/dashboard/AdminDashboard.tsx
@@ -1,4 +1,13 @@
+"use client";
+
+import ModulesList from "@/components/ModulesList";
+
 export default function AdminDashboard() {
-  return <div>Admin Dashboard</div>;
+  return (
+    <div>
+      <h1>Admin Dashboard</h1>
+      <ModulesList />
+    </div>
+  );
 }
 

--- a/src/app/dashboard/EmployeeDashboard.tsx
+++ b/src/app/dashboard/EmployeeDashboard.tsx
@@ -1,4 +1,13 @@
+"use client";
+
+import ModulesList from "@/components/ModulesList";
+
 export default function EmployeeDashboard() {
-  return <div>Employee Dashboard</div>;
+  return (
+    <div>
+      <h1>Employee Dashboard</h1>
+      <ModulesList />
+    </div>
+  );
 }
 

--- a/src/app/dashboard/OwnerDashboard.tsx
+++ b/src/app/dashboard/OwnerDashboard.tsx
@@ -1,4 +1,13 @@
+"use client";
+
+import ModulesList from "@/components/ModulesList";
+
 export default function OwnerDashboard() {
-  return <div>Owner Dashboard</div>;
+  return (
+    <div>
+      <h1>Owner Dashboard</h1>
+      <ModulesList />
+    </div>
+  );
 }
 

--- a/src/components/ModulesList.tsx
+++ b/src/components/ModulesList.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import useModules from "@/hooks/useModules";
+
+export default function ModulesList() {
+  const modules = useModules();
+  return (
+    <ul>
+      {modules.map((m) => (
+        <li key={m._id}>
+          {m.name} - {m.status}
+        </li>
+      ))}
+    </ul>
+  );
+}
+

--- a/src/hooks/useModules.ts
+++ b/src/hooks/useModules.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export interface ModuleInfo {
+  _id: string;
+  name: string;
+  status: string;
+}
+
+async function fetchModules(): Promise<ModuleInfo[]> {
+  const res = await fetch("/api/modules");
+  if (!res.ok) return [];
+  return res.json();
+}
+
+export default function useModules() {
+  const [modules, setModules] = useState<ModuleInfo[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function load() {
+      const data = await fetchModules();
+      if (mounted) setModules(data);
+    }
+
+    load();
+
+    const source = new EventSource("/api/modules/events");
+    const handler = () => {
+      void load();
+    };
+    source.addEventListener("module.online", handler);
+    source.addEventListener("module.offline", handler);
+    source.addEventListener("module.removed", handler);
+
+    return () => {
+      mounted = false;
+      source.close();
+    };
+  }, []);
+
+  return modules;
+}
+


### PR DESCRIPTION
## Summary
- Add ModuleList component and useModules hook to fetch modules and refresh on module events
- Implement role dashboards (owner, admin, employee) reusing shared layout
- Expose SSE endpoint for module status events

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e98a3324c8333a648341da313beca