### PR TITLE
Sync orchestrator metrics state after cycles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-_No changes yet._
+- Fixed orchestrator metrics to reflect running and active state after cycles.
 
 ## [0.5.3] - 2025-08-15
 

--- a/src/app/api/orchestrator/metrics/route.ts
+++ b/src/app/api/orchestrator/metrics/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getOrchestratorMetrics } from '@/services/moduleOrchestrator';
+import { getOrchestratorMetrics } from '../../../../services/moduleOrchestrator';
 
 export async function GET() {
   const metrics = getOrchestratorMetrics();

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -9,6 +9,7 @@ import {
 import Module from '../../models/Module';
 import * as eventBus from '../../messaging/eventBus';
 import logger from '../../lib/logger';
+import { GET as metricsRoute } from '../../app/api/orchestrator/metrics/route';
 
 let originalFetch: typeof fetch;
 
@@ -575,5 +576,24 @@ describe('moduleOrchestrator service', () => {
     assert.equal(m?.offline, 1);
     assert.ok(typeof m?.durationMs === 'number');
     assert.ok(typeof m?.timestamp === 'string');
+  });
+
+  it('reports isRunning=false via metrics endpoint when idle', async () => {
+    const modules = [
+      { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },
+    ];
+    (Module as any).find = createFindStub(modules);
+    (Module as any).findByIdAndUpdate = async () => {};
+    (global as any).fetch = async () => ({ ok: true }) as any;
+
+    startModuleOrchestrator({ intervalMs: 1_000 });
+    await new Promise((r) => setTimeout(r, 100));
+
+    const res = await metricsRoute();
+    const body = await res.json();
+    assert.equal(body.status, 'ok');
+    assert.equal(body.metrics.isRunning, false);
+    assert.equal(body.metrics.isActive, true);
+    stopModuleOrchestrator();
   });
 });

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -302,6 +302,10 @@ export function startModuleOrchestrator(options: OrchestratorOptions = {}) {
       logger.error('Module orchestration error', err);
     } finally {
       isRunning = false;
+      if (lastMetrics) {
+        lastMetrics.isRunning = isRunning;
+        lastMetrics.isActive = isActive;
+      }
       if (isActive) {
         if (timer) clearTimeout(timer);
         timer = setTimeout(run, intervalMs);


### PR DESCRIPTION
## Summary
- update orchestrator metrics so `isRunning` and `isActive` reflect real state after each cycle
- verify metrics endpoint reports idle state correctly
- note fix in changelog

## Testing
- `npm run lint`
- `NODE_ENV=test npx tsc -p tsconfig.tests.json && NODE_ENV=test node --test .tmp-tests/src/services/__tests__/moduleOrchestrator.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a02a78855c8333a33db7d9fb50952d