### PR TITLE
Handle ping URL update failures in orchestrator

### DIFF
--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -94,7 +94,11 @@ export async function checkModules(
       if (!mod.lastHandshake) {
         update.lastHandshake = new Date();
       }
-      await Module.findByIdAndUpdate(mod._id, update);
+      try {
+        await Module.findByIdAndUpdate(mod._id, update);
+      } catch (err) {
+        logger.error('Failed to update module status after invalid ping URL', err);
+      }
       if (!wasOffline) {
         try {
           await eventBus.publish('module.offline', { moduleId: String(mod._id) });


### PR DESCRIPTION
## Summary
- Guard `Module.findByIdAndUpdate` inside `pingModule` with try/catch
- Log database update errors so the orchestrator continues running

## Testing
- `npm run lint`
- `NODE_ENV=test MONGODB_URI= node --test .tmp-tests/src/services/__tests__/moduleOrchestrator.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a03772d0288333b6279ce2bcf5635a