### PR TITLE
Guard orchestrator startup on Mongo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fixed orchestrator metrics to reflect running and active state after cycles.
+- Module orchestrator skips execution when `MONGODB_URI` is missing, and instrumentation
+  refrains from starting the orchestrator without it.
 
 ## [0.5.3] - 2025-08-15
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ puede eliminar los que permanezcan offline demasiado tiempo. Consulta
 [docs/module-orchestrator.md](./docs/module-orchestrator.md) para conocer las opciones de
 configuración y los eventos emitidos.
 
-- Corre solo cuando `NEXT_RUNTIME=nodejs`.
+- Corre solo cuando `NEXT_RUNTIME=nodejs` y `MONGODB_URI` está configurada.
 - Intervalo configurable con `MODULE_ORCHESTRATOR_INTERVAL_MS` (ms).
 - Métricas del último ciclo disponibles en `GET /api/orchestrator/metrics`.
 

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -7,7 +7,8 @@ para notificar cambios de disponibilidad.
 ## Inicio y cierre
 
 El orquestador se inicia automáticamente cuando arranca el servidor y se detiene durante el
-apagado para liberar recursos. Esta lógica se encuentra en `instrumentation.ts`.
+apagado para liberar recursos. Solo se habilita si la variable `MONGODB_URI` está definida.
+Esta lógica se encuentra en `instrumentation.ts`.
 
 Durante el registro, el campo `endpoints.rest` debe ser una URL válida; de lo contrario, el módulo será rechazado.
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,11 @@
+import logger from './src/lib/logger';
+
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (!process.env.MONGODB_URI) {
+    logger.warn('MONGODB_URI is not set; module orchestrator will not start');
+    return;
+  }
   const orchestrator = await import('./src/services/moduleOrchestrator');
   const interval = process.env.MODULE_ORCHESTRATOR_INTERVAL_MS
     ? Number(process.env.MODULE_ORCHESTRATOR_INTERVAL_MS)

--- a/src/services/__tests__/moduleOrchestrator.test.ts
+++ b/src/services/__tests__/moduleOrchestrator.test.ts
@@ -49,6 +49,34 @@ afterEach(() => {
 });
 
 describe('moduleOrchestrator service', () => {
+  it('returns immediately when MONGODB_URI is missing outside tests', async () => {
+    const originalFind = Module.find;
+    const originalArgv = process.argv;
+    const origEnv = {
+      MONGODB_URI: process.env.MONGODB_URI,
+      NODE_ENV: process.env.NODE_ENV,
+    };
+    try {
+      delete (process.env as any).MONGODB_URI;
+      (process.env as any).NODE_ENV = 'production';
+      process.argv = ['node'];
+      let called = false;
+      (Module as any).find = () => {
+        called = true;
+        return { sort: () => ({ limit: async () => [] }) };
+      };
+      await checkModules();
+      assert.equal(called, false);
+    } finally {
+      Module.find = originalFind;
+      process.argv = originalArgv;
+      if (origEnv.MONGODB_URI)
+        (process.env as any).MONGODB_URI = origEnv.MONGODB_URI;
+      else delete (process.env as any).MONGODB_URI;
+      if (origEnv.NODE_ENV) (process.env as any).NODE_ENV = origEnv.NODE_ENV;
+      else delete (process.env as any).NODE_ENV;
+    }
+  });
   it('continues when findByIdAndUpdate fails', async () => {
     const modules = [
       { _id: '1', endpoints: { rest: 'http://m1' }, lastHandshake: new Date() },

--- a/src/services/moduleOrchestrator.ts
+++ b/src/services/moduleOrchestrator.ts
@@ -63,6 +63,10 @@ export async function checkModules(
   const argv = process.argv.join(' ');
   const isNodeTest = argv.includes('--test');
   const isTest = String(process.env.NODE_ENV).toLowerCase() === 'test' || isNodeTest;
+  if (!process.env.MONGODB_URI && !isTest) {
+    logger.warn('MONGODB_URI is not set; skipping module check');
+    return;
+  }
   if (process.env.MONGODB_URI) {
     try {
       await dbConnect();

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -14,21 +14,31 @@ describe('instrumentation', () => {
       started = true;
     };
     delete process.env.NEXT_RUNTIME;
+    delete process.env.MONGODB_URI;
   });
 
   afterEach(() => {
     (orchestrator as any).startModuleOrchestrator = origStart;
     delete process.env.NEXT_RUNTIME;
+    delete process.env.MONGODB_URI;
   });
 
-  it('starts orchestrator when running in node runtime', async () => {
+  it('starts orchestrator when running in node runtime and MONGODB_URI present', async () => {
     process.env.NEXT_RUNTIME = 'nodejs';
+    process.env.MONGODB_URI = 'mongodb://localhost/test';
     await register();
     assert.ok(started);
   });
 
+  it('does not start orchestrator when MONGODB_URI is missing', async () => {
+    process.env.NEXT_RUNTIME = 'nodejs';
+    await register();
+    assert.equal(started, false);
+  });
+
   it('does not start orchestrator in edge runtime', async () => {
     process.env.NEXT_RUNTIME = 'edge';
+    process.env.MONGODB_URI = 'mongodb://localhost/test';
     await register();
     assert.equal(started, false);
   });


### PR DESCRIPTION
## Summary
- Skip module checks when `MONGODB_URI` is absent outside tests
- Avoid starting the orchestrator when no `MONGODB_URI` is configured
- Document MongoDB requirement and add coverage for startup conditions

## Testing
- `npm run lint`
- `npx rimraf .tmp-tests && tsc -p tsconfig.tests.json && env -u MONGODB_URI NODE_ENV=test node --test $(find .tmp-tests \( -name '*.test.js' -o -name '*.spec.js' \))`


------
https://chatgpt.com/codex/tasks/task_e_68a03e88aba08333adefd18feead8772