### PR TITLE
Allow disabling module orchestrator via env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 - Fixed orchestrator metrics to reflect running and active state after cycles.
 - Module orchestrator skips execution when `MONGODB_URI` is missing, and instrumentation
   refrains from starting the orchestrator without it.
+- Module orchestrator can be disabled via `MODULE_ORCHESTRATOR_DISABLED`.
 
 ## [0.5.3] - 2025-08-15
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ puede eliminar los que permanezcan offline demasiado tiempo. Consulta
 configuración y los eventos emitidos.
 
 - Corre solo cuando `NEXT_RUNTIME=nodejs` y `MONGODB_URI` está configurada.
+- Puede deshabilitarse con `MODULE_ORCHESTRATOR_DISABLED=true`.
 - Intervalo configurable con `MODULE_ORCHESTRATOR_INTERVAL_MS` (ms).
 - Métricas del último ciclo disponibles en `GET /api/orchestrator/metrics`.
 

--- a/docs/module-orchestrator.md
+++ b/docs/module-orchestrator.md
@@ -7,8 +7,9 @@ para notificar cambios de disponibilidad.
 ## Inicio y cierre
 
 El orquestador se inicia automáticamente cuando arranca el servidor y se detiene durante el
-apagado para liberar recursos. Solo se habilita si la variable `MONGODB_URI` está definida.
-Esta lógica se encuentra en `instrumentation.ts`.
+apagado para liberar recursos. Solo se habilita si la variable `MONGODB_URI` está definida y
+se puede desactivar estableciendo `MODULE_ORCHESTRATOR_DISABLED=true`. Esta lógica se
+encuentra en `instrumentation.ts`.
 
 Durante el registro, el campo `endpoints.rest` debe ser una URL válida; de lo contrario, el módulo será rechazado.
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,6 +2,10 @@ import logger from './src/lib/logger';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (process.env.MODULE_ORCHESTRATOR_DISABLED === 'true') {
+    logger.info('Module orchestrator disabled via MODULE_ORCHESTRATOR_DISABLED');
+    return;
+  }
   if (!process.env.MONGODB_URI) {
     logger.warn('MONGODB_URI is not set; module orchestrator will not start');
     return;

--- a/src/tests/instrumentation.test.ts
+++ b/src/tests/instrumentation.test.ts
@@ -15,12 +15,14 @@ describe('instrumentation', () => {
     };
     delete process.env.NEXT_RUNTIME;
     delete process.env.MONGODB_URI;
+    delete process.env.MODULE_ORCHESTRATOR_DISABLED;
   });
 
   afterEach(() => {
     (orchestrator as any).startModuleOrchestrator = origStart;
     delete process.env.NEXT_RUNTIME;
     delete process.env.MONGODB_URI;
+    delete process.env.MODULE_ORCHESTRATOR_DISABLED;
   });
 
   it('starts orchestrator when running in node runtime and MONGODB_URI present', async () => {
@@ -39,6 +41,14 @@ describe('instrumentation', () => {
   it('does not start orchestrator in edge runtime', async () => {
     process.env.NEXT_RUNTIME = 'edge';
     process.env.MONGODB_URI = 'mongodb://localhost/test';
+    await register();
+    assert.equal(started, false);
+  });
+
+  it('skips orchestrator when MODULE_ORCHESTRATOR_DISABLED is true', async () => {
+    process.env.NEXT_RUNTIME = 'nodejs';
+    process.env.MONGODB_URI = 'mongodb://localhost/test';
+    process.env.MODULE_ORCHESTRATOR_DISABLED = 'true';
     await register();
     assert.equal(started, false);
   });


### PR DESCRIPTION
## Summary
- add `MODULE_ORCHESTRATOR_DISABLED` env to skip orchestrator startup
- document orchestrator disable flag in README and docs
- cover disabled orchestrator in instrumentation tests

## Testing
- `npm run lint`
- `npm test` *(fails: Could not find '/workspace/CoreFoundry/.tmp-tests/**/*.test.js')*
- `npx rimraf .tmp-tests && npx tsc -p tsconfig.tests.json && node --test $(find .tmp-tests -name '*.test.js') $(find .tmp-tests -name '*.spec.js') && npx rimraf .tmp-tests` *(fails: various module orchestrator tests with MongoDB connection errors and assertion failures)*


------
https://chatgpt.com/codex/tasks/task_e_68a041921aa8833391de02019d21a4fa