### PR TITLE
Handle orchestrator shutdown on process signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Module orchestrator skips execution when `MONGODB_URI` is missing, and instrumentation
   refrains from starting the orchestrator without it.
 - Module orchestrator can be disabled via `MODULE_ORCHESTRATOR_DISABLED`.
+- Instrumentation handles `SIGINT` and `SIGTERM` to stop the module orchestrator gracefully.
 
 ## [0.5.3] - 2025-08-15
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -15,5 +15,11 @@ export async function register() {
     ? Number(process.env.MODULE_ORCHESTRATOR_INTERVAL_MS)
     : undefined;
   orchestrator.startModuleOrchestrator(interval ? { intervalMs: interval } : undefined);
-  // Nota: no se registran señales de proceso para compatibilidad edge/serverless
+  const handleSignal = () => {
+    orchestrator.stopModuleOrchestrator();
+    process.off('SIGINT', handleSignal);
+    process.off('SIGTERM', handleSignal);
+  };
+  process.on('SIGINT', handleSignal);
+  process.on('SIGTERM', handleSignal);
 }


### PR DESCRIPTION
## Summary
- Stop module orchestrator when SIGINT or SIGTERM signals are received
- Remove signal listeners after shutdown to prevent leaks
- Document orchestrator signal handling

## Testing
- `npm run lint`
- `npm test` *(fails: Could not find '/workspace/CoreFoundry/.tmp-tests/**/*.test.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a042fd19308333bc370f0f15f7eaf5